### PR TITLE
Implement log rotation

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ args = parser.parse_args()
 from uav.interface import exit_flag, start_gui
 from uav.perception import OpticalFlowTracker, FlowHistory
 from uav.navigation import Navigator
-from uav.utils import get_drone_state
+from uav.utils import get_drone_state, retain_recent_logs
 
 # GUI parameter and status holders
 brake_base = [35.0]
@@ -65,6 +65,7 @@ timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
 os.makedirs("flow_logs", exist_ok=True)
 log_file = open(f"flow_logs/full_log_{timestamp}.csv", 'w')
 log_file.write("frame,time,features,flow_left,flow_center,flow_right,speed,simgetimage_s,decode_s,processing_s,loop_s\n")
+retain_recent_logs("flow_logs")
 
 # Video writer setup
 fourcc = cv2.VideoWriter_fourcc(*'MJPG')
@@ -221,6 +222,7 @@ try:
             timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
             log_file = open(f"flow_logs/full_log_{timestamp}.csv", 'w')
             log_file.write("frame,time,features,flow_left,flow_center,flow_right,speed,simgetimage_s,decode_s,processing_s,loop_s\n")
+            retain_recent_logs("flow_logs")
 
             # === Reset video writer ===
             out.release()

--- a/uav/utils.py
+++ b/uav/utils.py
@@ -3,6 +3,7 @@ import math
 import cv2
 import numpy as np
 import airsim
+import os
 
 def apply_clahe(gray_image):
     clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
@@ -22,3 +23,28 @@ def get_drone_state(client):
     vel = state.kinematics_estimated.linear_velocity
     speed = get_speed(vel)
     return pos, yaw, speed
+
+
+def retain_recent_logs(log_dir: str, keep: int = 5) -> None:
+    """Keep only the `keep` most recent log files in *log_dir*.
+
+    Files are ordered by modification time. Older files beyond the
+    desired count are silently removed.
+    """
+
+    try:
+        logs = [
+            os.path.join(log_dir, f)
+            for f in os.listdir(log_dir)
+            if f.endswith(".csv")
+        ]
+    except FileNotFoundError:
+        return
+
+    logs.sort(key=os.path.getmtime, reverse=True)
+
+    for old_log in logs[keep:]:
+        try:
+            os.remove(old_log)
+        except OSError:
+            pass


### PR DESCRIPTION
## Summary
- add `retain_recent_logs` to keep only 5 most recent log files
- call log cleanup whenever new logs are created

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840b18285808325ae295e6b2b7bf66a