### PR TITLE
Add UE4_PATH env var support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -61,12 +61,12 @@ pytest
 ## Running the Simulation
 
 1. Launch the AirSim Unreal environment.
-2. Run the script. You can override the path to the Unreal Engine executable using `--ue4-path`:
+2. Run the script. You can override the path to the Unreal Engine executable using `--ue4-path` or by setting the `UE4_PATH` environment variable:
 
    ```bash
    python main.py --ue4-path "C:\\Path\\To\\Blocks.exe"
    ```
-   If omitted, the path defaults to the value used during development.
+   If omitted, the path defaults to `UE4_PATH` if set, otherwise to the value used during development.
 
 3. The GUI displays the STOP button along with left/center/right flow values and the current state. Click STOP to end the simulation cleanly.
 

--- a/main.py
+++ b/main.py
@@ -12,9 +12,17 @@ import argparse
 # Default path to the Unreal Engine simulator used during development
 DEFAULT_UE4_PATH = r"C:\Users\newso\Documents\AirSimExperiments\BlocksBuild\WindowsNoEditor\Blocks\Binaries\Win64\Blocks.exe"
 
+# Allow overriding the path via environment variable
+ENV_UE4_PATH = os.environ.get("UE4_PATH")
+ue4_default = ENV_UE4_PATH if ENV_UE4_PATH else DEFAULT_UE4_PATH
+
 parser = argparse.ArgumentParser(description="Optical flow navigation script")
 parser.add_argument("--manual-nudge", action="store_true", help="Enable manual nudge at frame 5 for testing")
-parser.add_argument("--ue4-path", default=DEFAULT_UE4_PATH, help="Path to the Unreal Engine executable")
+parser.add_argument(
+    "--ue4-path",
+    default=ue4_default,
+    help="Path to the Unreal Engine executable (or set UE4_PATH env variable)",
+)
 args = parser.parse_args()
 
 from uav.interface import exit_flag, start_gui


### PR DESCRIPTION
## Summary
- support `UE4_PATH` env var in `main.py`
- document `UE4_PATH` usage in README

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6840b7bfc4f083259fc9c4c90540ac0f