### PR TITLE
Add pandas, plotly, scipy dependencies

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -42,6 +42,7 @@ AirSimExperiments/
 * Python 3.8+
 * AirSim installed and configured
 * Python dependencies listed in `requirements.txt`
+* Additional packages: `pandas`, `plotly`, and `scipy`
 
 Install the Python packages with:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ numpy
 airsim
 msgpack-rpc-python
 msgpack
+pandas
+plotly
+scipy


### PR DESCRIPTION
## Summary
- add pandas, plotly, scipy to requirements
- update README requirements section to mention these packages

## Testing
- `pip install -r requirements.txt` *(fails: airsim build depends on numpy during build)*

------
https://chatgpt.com/codex/tasks/task_e_68418b2b832c8325ae29982d4203b2a5