### PR TITLE
Add visualization flags

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -87,6 +87,20 @@ frame,time,features,flow_left,flow_center,flow_right,flow_std,pos_x,pos_y,pos_z,
 1,0.05,120,3.2,1.1,2.0,0.8,0.12,0.00,-2.00,0.0,1.7,resume,0,50.0,8.0,20.0,18.5
 ```
 
+## Visualizing Flights
+
+You can generate an interactive HTML view of a flight log using
+`analysis/visualize_flight.py`:
+
+```bash
+python analysis/visualize_flight.py --log flow_logs/run.csv
+```
+
+Optional flags:
+
+* `--flip-y` &ndash; flip the Y axis of the trajectory before plotting.
+* `--no-align` &ndash; do not align the path to the starting marker.
+
 ## Future Improvements
 
 * Add SLAM integration


### PR DESCRIPTION
## Summary
- extend `visualize_flight.py` argument parser
- apply Y-axis flip only when requested
- support skipping initial alignment
- document the new options in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68418b3a6ea883259f5297f82f16517c