### PR TITLE
Fix loop timing during settling phase

### DIFF
--- a/main.py
+++ b/main.py
@@ -151,6 +151,9 @@ def main():
                     except Exception:
                         pass
 
+                    # Reset loop timing so loop_s reflects the settle delay only
+                    loop_start = time.time()
+
                     continue
 
                 else:


### PR DESCRIPTION
## Summary
- reset loop_start time when settling to avoid inflated loop durations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fd0d3c4883258fd23a737ea8934b