### PR TITLE
Add contributor guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Contributor Guidelines
+
+- Run `pytest` before committing to ensure all tests pass.
+- Install dependencies with `pip install -r requirements.txt` if needed.
+- Keep documentation in sync with code changes, especially `README.txt`.

--- a/README.txt
+++ b/README.txt
@@ -153,6 +153,10 @@ with basic statistics for each log.
 * Command line argument parsing for tuning thresholds
 * ROS bridge for physical deployment
 
+## Contributing
+
+See `AGENTS.md` for developer guidelines. Always run `pytest` before submitting changes.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add AGENTS.md with simple contributor guidelines
- document AGENTS instructions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441e1935f08325ad6d2ac1bbc9eeba