### PR TITLE
Add configurable paths for UE4 and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ This repository contains the implementation of a reactive obstacle avoidance sys
    ```bash
    python main.py --settings-path C:\path\to\settings.json --ue4-path C:\path\to\Blocks.exe
    ```
+   To load a different configuration file:
+   ```bash
+   python main.py --config custom.ini
+   ```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,15 @@ This repository contains the implementation of a reactive obstacle avoidance sys
 
 4. Build your Unreal map and generate a packaged `.exe` (e.g. `Blocks.exe`).
 
-5. Run the system:
+5. Edit `config.ini` to point to your AirSim `settings.json` and UE4 executables. These values will be used unless overridden on the command line.
+
+6. Run the system:
    ```bash
    python main.py
+   ```
+   You can override paths at runtime:
+   ```bash
+   python main.py --settings-path C:\path\to\settings.json --ue4-path C:\path\to\Blocks.exe
    ```
 
 ---

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,7 @@
+[paths]
+settings = C:\\Users\\Jacob\\Documents\\AirSim\\settings.json
+
+[ue4]
+reactive = H:\\Documents\\AirSimBuilds\\Reactive\\WindowsNoEditor\\Blocks\\Binaries\\Win64\\Blocks.exe
+deliberative = H:\\Documents\\AirSimBuilds\\Deliberative\\WindowsNoEditor\\Blocks\\Binaries\\Win64\\Blocks.exe
+hybrid = H:\\Documents\\AirSimBuilds\\Hybrid\\WindowsNoEditor\\Blocks\\Binaries\\Win64\\Blocks.exe

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from uav.nav_loop import (
 import airsim
 import logging
 from uav.utils import FLOW_STD_MAX as UTIL_FLOW_STD_MAX
+from uav.config import load_app_config
 
 FLOW_STD_MAX = UTIL_FLOW_STD_MAX
 
@@ -18,7 +19,9 @@ SETTINGS_PATH = r"C:\Users\Jacob\Documents\AirSim\settings.json"
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     args = parse_args()
-    sim_process = launch_sim(args, SETTINGS_PATH)
+    config = load_app_config(args.config)
+    settings_path = args.settings_path or config.get("paths", "settings", fallback=SETTINGS_PATH)
+    sim_process = launch_sim(args, settings_path, config)
 
     client = airsim.MultirotorClient()
     client.confirmConnection()

--- a/uav/cli.py
+++ b/uav/cli.py
@@ -5,6 +5,8 @@ def parse_args():
     parser.add_argument("--manual-nudge", action="store_true", help="Enable manual nudge at frame 5 for testing")
     parser.add_argument("--map", choices=["reactive", "deliberative", "hybrid"], default="reactive", help="Which map to load")
     parser.add_argument("--ue4-path", default=None, help="Override the default path to the Unreal Engine executable")
+    parser.add_argument("--settings-path", default=None, help="Path to AirSim settings.json")
+    parser.add_argument("--config", default="config.ini", help="Path to config file with default paths")
     parser.add_argument("--goal-x", type=int, default=29, help="Distance from start to goal (X coordinate)")
     parser.add_argument("--max-duration", type=int, default=60, help="Maximum simulation duration in seconds")
     return parser.parse_args()

--- a/uav/config.py
+++ b/uav/config.py
@@ -13,3 +13,10 @@ LOG_INTERVAL = 5
 VIDEO_FPS = 8.0
 VIDEO_SIZE = (1280, 720)
 VIDEO_OUTPUT = 'flow_output.avi'
+
+def load_app_config(config_path: str = "config.ini"):
+    """Load application config from an INI file."""
+    import configparser
+    parser = configparser.ConfigParser()
+    parser.read(config_path)
+    return parser

--- a/uav/sim_launcher.py
+++ b/uav/sim_launcher.py
@@ -2,10 +2,11 @@ import subprocess
 import time
 import logging
 from configparser import ConfigParser
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-def launch_sim(args, settings_path, config: ConfigParser | None = None):
+def launch_sim(args, settings_path, config: Optional[ConfigParser] = None):
     map_launch_args = {
         "reactive": "/Game/Maps/Map_Reactive",
         "deliberative": "/Game/Maps/Map_Deliberative",

--- a/uav/sim_launcher.py
+++ b/uav/sim_launcher.py
@@ -1,10 +1,11 @@
 import subprocess
 import time
 import logging
+from configparser import ConfigParser
 
 logger = logging.getLogger(__name__)
 
-def launch_sim(args, settings_path):
+def launch_sim(args, settings_path, config: ConfigParser | None = None):
     map_launch_args = {
         "reactive": "/Game/Maps/Map_Reactive",
         "deliberative": "/Game/Maps/Map_Deliberative",
@@ -12,12 +13,19 @@ def launch_sim(args, settings_path):
     }
 
     exe_paths = {
-        "reactive": r"H:\Documents\AirSimBuilds\Reactive\WindowsNoEditor\Blocks\Binaries\Win64\Blocks.exe",
-        "deliberative": r"H:\Documents\AirSimBuilds\Deliberative\WindowsNoEditor\Blocks\Binaries\Win64\Blocks.exe",
-        "hybrid": r"H:\Documents\AirSimBuilds\Hybrid\WindowsNoEditor\Blocks\Binaries\Win64\Blocks.exe"
+        "reactive": r"H:\\Documents\\AirSimBuilds\\Reactive\\WindowsNoEditor\\Blocks\\Binaries\\Win64\\Blocks.exe",
+        "deliberative": r"H:\\Documents\\AirSimBuilds\\Deliberative\\WindowsNoEditor\\Blocks\\Binaries\\Win64\\Blocks.exe",
+        "hybrid": r"H:\\Documents\\AirSimBuilds\\Hybrid\\WindowsNoEditor\\Blocks\\Binaries\\Win64\\Blocks.exe"
     }
 
-    ue4_exe = args.ue4_path if args.ue4_path else exe_paths[args.map]
+    config_exe = None
+    if config is not None:
+        try:
+            config_exe = config.get("ue4", args.map)
+        except Exception:
+            config_exe = None
+
+    ue4_exe = args.ue4_path or config_exe or exe_paths[args.map]
     map_path = map_launch_args[args.map]
 
     sim_cmd = [


### PR DESCRIPTION
## Summary
- add `config.ini` for default executable and settings paths
- support `--config` and `--settings-path` CLI options
- load config in `main.py` and `sim_launcher`
- document configuration in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860401799e48325b6c1cbe60d323ac0