### PR TITLE
Fix overlay writing order

### DIFF
--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -366,17 +366,6 @@ def write_frame_output(
     flow_std,
 ):
     """Write video frame, overlay and log data."""
-    write_video_frame(frame_queue, vis_img)
-
-    elapsed = time.time() - loop_start
-    if elapsed < frame_duration:
-        time.sleep(frame_duration - elapsed)
-    loop_elapsed = time.time() - loop_start
-    actual_fps = 1 / max(loop_elapsed, 1e-6)
-    loop_start = time.time()
-
-    fps_list.append(actual_fps)
-
     pos, yaw, speed = get_drone_state(client)
     collision = client.simGetCollisionInfo()
     collided = int(getattr(collision, "has_collided", False))
@@ -396,6 +385,17 @@ def write_frame_output(
         flow_vectors,
         in_grace=in_grace,
     )
+
+    write_video_frame(frame_queue, vis_img)
+
+    elapsed = time.time() - loop_start
+    if elapsed < frame_duration:
+        time.sleep(frame_duration - elapsed)
+    loop_elapsed = time.time() - loop_start
+    actual_fps = 1 / max(loop_elapsed, 1e-6)
+    loop_start = time.time()
+
+    fps_list.append(actual_fps)
 
     log_line = format_log_line(
         frame_count,


### PR DESCRIPTION
## Summary
- draw the nav overlay before queuing frames for output
- ensure the queued frame includes overlays

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- run a small overlay rendering check

------
https://chatgpt.com/codex/tasks/task_e_68612528f88483259c95cf3d1506187c