### PR TITLE
Update blind_forward grace logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ pip install -e .
 - The system captures images from a front-facing virtual camera
 - Optical flow vectors are extracted and used to detect motion in different zones
 - The UAV avoids obstacles by adjusting yaw based on zone flow magnitudes
+- After the first forward command a brief grace period suppresses additional navigation actions
 
 ---
 

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -1,5 +1,7 @@
 import unittest.mock as mock
 import time
+from collections import deque
+from queue import Queue
 from tests.conftest import airsim_stub
 
 from uav.navigation import Navigator
@@ -148,3 +150,66 @@ def test_resume_forward_not_called_during_grace():
     ):
         nav.resume_forward()
     nav.resume_forward.assert_not_called()
+
+
+def test_blind_forward_starts_grace_once():
+    client = DummyClient()
+    nav = Navigator(client)
+    before = time.time()
+    nav.grace_used = False
+
+    nav.blind_forward()
+
+    assert nav.just_resumed is True
+    assert nav.grace_used is True
+    assert nav.resume_grace_end_time >= before + 0.9
+    first_end = nav.resume_grace_end_time
+
+    nav.blind_forward()
+
+    assert nav.resume_grace_end_time == first_end
+
+
+def test_navigation_skips_actions_during_grace_after_blind_forward(monkeypatch):
+    import importlib
+    import types
+    import sys
+
+    airsim_stub = types.SimpleNamespace(ImageRequest=object, ImageType=object)
+    monkeypatch.setitem(sys.modules, 'airsim', airsim_stub)
+    nl = importlib.import_module('uav.nav_loop')
+    importlib.reload(nl)
+    navigation_step = nl.navigation_step
+
+    client = DummyClient()
+    nav = Navigator(client)
+    nav.blind_forward()
+    frame_q = Queue()
+    params = {'state': [None]}
+    result = navigation_step(
+        client,
+        nav,
+        None,
+        [],
+        None,
+        0.0,
+        2.0,
+        0.1,
+        2.0,
+        0.0,
+        0,
+        0,
+        0,
+        0,
+        frame_q,
+        object(),
+        time.time(),
+        1,
+        None,
+        deque(maxlen=10),
+        deque(maxlen=10),
+        params,
+    )
+
+    assert result[0] == "none"
+    assert client.moveByVelocityAsync.call_count == 1

--- a/uav/navigation.py
+++ b/uav/navigation.py
@@ -123,6 +123,10 @@ class Navigator:
             yaw_mode=airsim.YawMode(False, 0),
         )
         self.last_movement_time = time.time()
+        if not self.grace_used:
+            self.just_resumed = True
+            self.resume_grace_end_time = time.time() + 1.0
+            self.grace_used = True
         return "blind_forward"
 
     def nudge(self):


### PR DESCRIPTION
## Summary
- start grace period when blind_forward is first called
- document brief grace period in README
- test new blind_forward grace behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68613901106c8325996ead6fbbbcfd9f