### PR TITLE
Add optical flow delta tracking

### DIFF
--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -197,6 +197,7 @@ def test_navigation_skips_actions_during_grace_after_blind_forward(monkeypatch):
         0.1,
         2.0,
         0.0,
+        0.0,
         0,
         0,
         0,

--- a/uav/logging_utils.py
+++ b/uav/logging_utils.py
@@ -1,12 +1,15 @@
 def format_log_line(
-    frame_count, time_now, good_old, smooth_L, smooth_C, smooth_R, flow_std,
+    frame_count, time_now, good_old,
+    smooth_L, smooth_C, smooth_R,
+    delta_L, delta_C, delta_R, flow_std,
     pos, yaw, speed, state_str, collided, obstacle_detected, side_safe,
     brake_thres, dodge_thres, probe_req, actual_fps,
-    simgetimage_s, decode_s, processing_s, loop_elapsed
+    simgetimage_s, decode_s, processing_s, loop_elapsed,
 ):
     return (
         f"{frame_count},{time_now:.2f},{len(good_old)},"
-        f"{smooth_L:.3f},{smooth_C:.3f},{smooth_R:.3f},{flow_std:.3f},"
+        f"{smooth_L:.3f},{smooth_C:.3f},{smooth_R:.3f},"
+        f"{delta_L:.3f},{delta_C:.3f},{delta_R:.3f},{flow_std:.3f},"
         f"{pos.x_val:.2f},{pos.y_val:.2f},{pos.z_val:.2f},{yaw:.2f},{speed:.2f},{state_str},{collided},{obstacle_detected},{int(side_safe)},"
         f"{brake_thres:.2f},{dodge_thres:.2f},{probe_req:.2f},{actual_fps:.2f},"
         f"{simgetimage_s:.3f},{decode_s:.3f},{processing_s:.3f},{loop_elapsed:.3f}\n"

--- a/uav/navigation.py
+++ b/uav/navigation.py
@@ -35,9 +35,11 @@ class Navigator:
     def brake(self):
         """Stop the drone immediately."""
         logger.info("\U0001F6D1 Braking")
-        # self.client.moveByVelocityAsync(0, 0, 0, 1) # Stop all velocity for duration 1 second
-        pos = self.client.getMultirotorState().kinematics_estimated.position
-        self.client.moveToPositionAsync(pos.x_val, pos.y_val, pos.z_val, 1)
+        try:
+            pos = self.client.getMultirotorState().kinematics_estimated.position
+            self.client.moveToPositionAsync(pos.x_val, pos.y_val, pos.z_val, 1)
+        except AttributeError:
+            self.client.moveByVelocityAsync(0, 0, 0, 1)
         self.braked = True
         return "brake"
 

--- a/uav/overlay.py
+++ b/uav/overlay.py
@@ -3,6 +3,7 @@ import numpy as np
 
 def draw_overlay(vis_img, frame_count, speed, state, sim_time,
                  smooth_L, smooth_C, smooth_R,
+                 delta_L, delta_C, delta_R,
                  left_count, center_count, right_count,
                  good_old, flow_vectors,
                  in_grace=False):
@@ -37,6 +38,9 @@ def draw_overlay(vis_img, frame_count, speed, state, sim_time,
     cv2.putText(img, f"L: {smooth_L:.1f} ({left_count})", (10, 50), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 0), 2)
     cv2.putText(img, f"C: {smooth_C:.1f} ({center_count})", (third + 10, 50), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 0), 2)
     cv2.putText(img, f"R: {smooth_R:.1f} ({right_count})", (2 * third + 10, 50), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 0), 2)
+    cv2.putText(img, f"ΔL: {delta_L:+.2f}", (10, 70), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 255), 2)
+    cv2.putText(img, f"ΔC: {delta_C:+.2f}", (third + 10, 70), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 255), 2)
+    cv2.putText(img, f"ΔR: {delta_R:+.2f}", (2 * third + 10, 70), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 255), 2)
 
     # Status overlay
     cv2.putText(img, f"Frame: {frame_count}", (10, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)


### PR DESCRIPTION
## Summary
- track previous smoothed flow values and compute deltas
- react to sudden center flow increase in `navigation_step`
- overlay and log the new delta values
- handle missing `getMultirotorState` in navigator tests
- update tests for new navigation_step signature

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616d0b3ec08325a40c5e9b3805adf4