### PR TITLE
Refactor launch orchestration

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,6 +122,8 @@ def main() -> None:
         logger.info(f"🗺️  Initial state: {ctx['param_refs']['state'][0]}")
         logger.info(f"📦 Perception thread running: {ctx['perception_thread'].is_alive()}")
 
+        # The navigation loop internally checks ``navigator.settling`` and
+        # should proceed normally at this level.
         try:
             navigation_loop(args, client, ctx)
 

--- a/tests/test_launch_all_helpers.py
+++ b/tests/test_launch_all_helpers.py
@@ -1,0 +1,46 @@
+import subprocess
+from datetime import datetime
+import importlib, sys, types
+
+if 'pygetwindow' not in sys.modules:
+    sys.modules['pygetwindow'] = types.SimpleNamespace(getAllTitles=lambda: [])
+
+import launch_all
+
+class DummyProc:
+    pass
+
+
+def test_start_streamer_invokes_subprocess(monkeypatch):
+    calls = []
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd: calls.append(cmd) or DummyProc())
+    proc = launch_all.start_streamer("127.0.0.1", 5555)
+    assert isinstance(proc, DummyProc)
+    assert calls and calls[0][0] == "python"
+    assert "--host" in calls[0] and "--port" in calls[0]
+
+
+def test_launch_slam_backend_invokes_subprocess(monkeypatch):
+    calls = []
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd: calls.append(cmd) or DummyProc())
+    proc = launch_all.launch_slam_backend("1.2.3.4", 6001)
+    assert isinstance(proc, DummyProc)
+    assert calls and "POSE_RECEIVER_IP=1.2.3.4" in calls[0][-1]
+
+
+def test_record_slam_video_returns_path(monkeypatch):
+    calls = []
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd: calls.append(cmd) or DummyProc())
+    monkeypatch.setattr(launch_all.gw, "getAllTitles", lambda: ["ORB-SLAM2"])
+
+    class DummyDT:
+        @staticmethod
+        def now():
+            return datetime(2020, 1, 1, 0, 0, 0)
+    monkeypatch.setattr(launch_all, "datetime", DummyDT)
+
+    proc, path = launch_all.record_slam_video("ORB-SLAM2", duration=5)
+    assert isinstance(proc, DummyProc)
+    assert path.endswith("20200101_000000.mp4")
+    assert calls and calls[0][0] == "ffmpeg"
+


### PR DESCRIPTION
## Summary
- break up `launch_all` main steps into helper functions
- document navigation loop expectations in `main.py`
- add tests covering new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec9152da083258c563c81f6c1adcd