### PR TITLE
Fix log_event recursion with empty path

### DIFF
--- a/linux_slam/app/tcp_slam_server.cpp
+++ b/linux_slam/app/tcp_slam_server.cpp
@@ -97,7 +97,6 @@ static void log_event(const std::string& msg) {
 
     if (g_log_file_path.empty()) {
         if (!warned) {
-            log_event("[WARN] Logging is disabled because g_log_file_path is empty.");
             std::cerr << "[WARN] Logging is disabled because g_log_file_path is empty." << std::endl;
             warned = true;
         }


### PR DESCRIPTION
## Summary
- remove self-recursive log_event call when log path unset
- attempted cmake build (fails due to missing Pangolin)
- run pytest

## Testing
- `cmake -S linux_slam -B linux_slam/build`
- `cmake --build linux_slam/build` *(fails: Makefile not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b4f6b24548325abb36de29bbd4e52