### PR TITLE
Add c++14 path helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ Simulation* writes `nav_mode.flag`. Once all systems report ready, clicking
 Pressing the stop button touches `stop.flag` so the running process can safely
 land and exit.
 
+### SLAM Utilities
+
+Two helper applications live under `linux_slam/app`:
+
+- `offline_slam_evaluation` now accepts `--data-dir=DIR` to specify where RGB and depth images are loaded from.
+- `tcp_slam_server` reads log and flag locations from the command line or the environment variables `SLAM_LOG_DIR`, `SLAM_FLAG_DIR` and `SLAM_IMAGE_DIR`.
+
 
 ---
 

--- a/linux_slam/app/offline_slam_evaluation.cpp
+++ b/linux_slam/app/offline_slam_evaluation.cpp
@@ -31,18 +31,46 @@ bool SendPose(int sockfd, const cv::Mat& Tcw) {
     return sent == sizeof(data);
 }
 
+// Simple cross-platform helpers for path handling
+#ifdef _WIN32
+const char PATH_SEP = '\\';
+#else
+const char PATH_SEP = '/';
+#endif
+
+static std::string join_path(const std::string& base, const std::string& file) {
+    if (base.empty()) return file;
+    if (base.back() == PATH_SEP) return base + file;
+    return base + PATH_SEP + file;
+}
+
 int main(int argc, char **argv) {
-    string base_path = "/home/jacob/slam_ws/ORB_SLAM2_clean/app/"; // Base path for image files, adjust as needed
 
-    if (argc < 4 || argc > 5) {
-        cerr << "Usage: ./custom_slam path_to_vocabulary path_to_settings associate.txt [receiver_ip]" << endl;
+    string data_dir = "";
+    vector<string> args;
+
+    for (int i = 1; i < argc; ++i) {
+        string arg = argv[i];
+        const string prefix = "--data-dir=";
+        if (arg.rfind(prefix, 0) == 0) {
+            data_dir = arg.substr(prefix.size());
+        } else {
+            args.push_back(arg);
+        }
+    }
+
+    if (args.size() < 3 || args.size() > 4) {
+        cerr << "Usage: ./custom_slam [--data-dir=DIR] path_to_vocabulary path_to_settings associate.txt [receiver_ip]" << endl;
         return 1;
-    } 
+    }
 
-    string vocab = argv[1];
-    string settings = argv[2];
-    string assoc_file = argv[3];
-    string receiver_ip = (argc == 5) ? argv[4] : "172.23.31.187"; // default IP or pass as argument
+    std::string base_path = data_dir.empty() ? "." : data_dir;
+
+    string vocab = args[0];
+    string settings = args[1];
+    string assoc_file = args[2];
+    string receiver_ip = (args.size() == 4) ? args[3] : "172.23.31.187"; // default IP or pass as argument
+
 
     // DEBUG: start timer before vocabulary load
     cout << "[DEBUG] Starting vocabulary load..." << endl;
@@ -104,8 +132,8 @@ int main(int argc, char **argv) {
 
     // Process each frame
     for (size_t i = 0; i < rgb_files.size(); ++i) {
-        string rgb_path = base_path + rgb_files[i];
-        string depth_path = base_path + depth_files[i];
+        std::string rgb_path = join_path(base_path, rgb_files[i]);
+        std::string depth_path = join_path(base_path, depth_files[i]);
 
         cout << "[DEBUG] Frame " << i << " timestamps - RGB: " << timestamps[i] << endl;
         cout << "[DEBUG] Loading RGB image from: " << rgb_path << endl;

--- a/linux_slam/app/tcp_slam_server.cpp
+++ b/linux_slam/app/tcp_slam_server.cpp
@@ -14,6 +14,10 @@
 #include <sstream>
 #include <mutex>
 #include <sys/stat.h>
+#include <cerrno>
+#ifdef _WIN32
+#include <direct.h>
+#endif
 
 // Define grace period parameters at the top of the main function
 int grace_frame_count = 0;  // Counter for frames with no detected motion
@@ -213,46 +217,84 @@ void cleanup_resources(int sock, int server_fd, int pose_sock) {
 }
 
 // ------- Main function to set up the TCP server, receive images, and process them with ORB-SLAM2 -------
+// Simple cross-platform helpers
+#ifdef _WIN32
+const char PATH_SEP = '\\';
+#else
+const char PATH_SEP = '/';
+#endif
+
+static bool make_dir(const std::string& p) {
+#ifdef _WIN32
+    return _mkdir(p.c_str()) == 0 || errno == EEXIST;
+#else
+    return mkdir(p.c_str(), 0755) == 0 || errno == EEXIST;
+#endif
+}
+
+static bool create_directories(const std::string& path) {
+    std::string accum;
+    for (size_t i = 0; i < path.size(); ++i) {
+        char c = path[i];
+        accum += c;
+        if (c == '/' || c == '\\') {
+            if (!accum.empty()) make_dir(accum);
+        }
+    }
+    if (!accum.empty()) make_dir(accum);
+    return true;
+}
+
+static std::string join_path(const std::string& a, const std::string& b) {
+    if (a.empty()) return b;
+    if (a.back() == PATH_SEP) return a + b;
+    return a + PATH_SEP + b;
+}
+
 int main(int argc, char **argv) {
-    // Redirect stdout and stderr to log files
-    (void)freopen("/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/logs/slam_console.txt", "w", stdout);
-    (void)freopen("/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/logs/slam_console_err.txt", "w", stderr);
+
+    std::string log_dir = getenv("SLAM_LOG_DIR") ? getenv("SLAM_LOG_DIR") : "logs";
+    std::string flag_dir = getenv("SLAM_FLAG_DIR") ? getenv("SLAM_FLAG_DIR") : "flags";
+    std::string image_dir = getenv("SLAM_IMAGE_DIR") ? getenv("SLAM_IMAGE_DIR") : join_path(log_dir, "images");
+
+    if (argc < 3) {
+        cerr << "Usage: ./tcp_slam_server vocab settings [log_dir] [flag_dir]" << endl;
+        return 1;
+    }
+
+    if (argc >= 4) log_dir = argv[3];
+    if (argc >= 5) flag_dir = argv[4];
+    if (argc >= 6) image_dir = argv[5];
+
+    create_directories(log_dir);
+    create_directories(flag_dir);
+    create_directories(image_dir);
+
+    std::string console_log = join_path(log_dir, "slam_console.txt");
+    std::string console_err = join_path(log_dir, "slam_console_err.txt");
+
+    (void)freopen(console_log.c_str(), "w", stdout);
+    (void)freopen(console_err.c_str(), "w", stderr);
+
     // Set the locale to C for consistent number formatting
-    
+
     // Add this static variable at the top of your main function
     static cv::Mat prev_Tcw;  // Previous pose (initialize once)
 
-    if (argc < 3) {
-        cerr << "Usage: ./tcp_slam_server path_to_vocabulary path_to_settings [log_file_path]" << endl;
-        return 1;
-    }
-    // Create logs directory if it doesn't exist
-    #ifdef _WIN32
-        _mkdir("H:\\Documents\\AirSimExperiments\\Hybrid_Navigation\\logs");
-    #else
-        mkdir("/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/logs", 0777);
-    #endif
-
-    // Create images directory if it doesn't exist
-    #ifdef _WIN32
-        _mkdir("H:\\Documents\\AirSimExperiments\\Hybrid_Navigation\\images");
-    #else
-        mkdir("/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/images", 0777);
-    #endif
-    
     // Get vocabulary and settings file paths from command line arguments
     std::string vocab = argv[1];
     std::string settings = argv[2];
 
     // Set log file path with timestamp if not provided
-    if (argc >= 4) {
-        g_log_file_path = argv[3];
+    const char* log_file_env = getenv("SLAM_LOG_FILE");
+    if (log_file_env) {
+        g_log_file_path = log_file_env;
     } else {
         std::ostringstream oss;
         std::time_t t = std::time(nullptr);
         char timebuf[32];
         std::strftime(timebuf, sizeof(timebuf), "%Y%m%d_%H%M%S", std::localtime(&t));
-        oss << "/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/logs/slam_server_debug_" << timebuf << ".log";
+        oss << join_path(log_dir, std::string("slam_server_debug_") + timebuf + ".log");
         g_log_file_path = oss.str();
     }
 
@@ -261,7 +303,7 @@ int main(int argc, char **argv) {
     std::time_t pose_log_t = std::time(nullptr);
     char pose_log_timebuf[32];
     std::strftime(pose_log_timebuf, sizeof(pose_log_timebuf), "%Y%m%d_%H%M%S", std::localtime(&pose_log_t));
-    pose_log_oss << "/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/logs/pose_sent_" << pose_log_timebuf << ".log";
+    pose_log_oss << join_path(log_dir, std::string("pose_sent_") + pose_log_timebuf + ".log");
     std::string pose_log_file_path = pose_log_oss.str();
     std::ofstream pose_log_stream(pose_log_file_path, std::ios::app);
 
@@ -797,7 +839,7 @@ int main(int argc, char **argv) {
                     cv::Mat rgb_kp;
                     cv::drawKeypoints(imLeft, orb_kps, rgb_kp);
                     std::ostringstream kp_filename;
-                    kp_filename << "/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/images/frame_rgb_kp_" << frame_counter << ".png";
+                    kp_filename << join_path(image_dir, std::string("frame_rgb_kp_") + std::to_string(frame_counter) + ".png");
                     cv::imwrite(kp_filename.str(), rgb_kp);
                 }
             }
@@ -824,7 +866,7 @@ int main(int argc, char **argv) {
 
                 // Write the slam_ready.flag only once, after SLAM becomes valid
                 if (!slam_ready_flag_written) {
-                    std::string flag_path = "/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/flags/slam_ready.flag";
+                    std::string flag_path = join_path(flag_dir, "slam_ready.flag");
                     std::ofstream flag_file(flag_path);
                     if (flag_file.is_open()) {
                         flag_file << "SLAM_READY" << std::endl;
@@ -931,8 +973,8 @@ int main(int argc, char **argv) {
     log_event("[DEBUG] Sockets closed. SLAM server shutting down.");
     SLAM.Shutdown();
 
-    SLAM.SaveTrajectoryTUM("/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/CameraTrajectory.txt");
-    SLAM.SaveKeyFrameTrajectoryTUM("/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/KeyFrameTrajectory.txt");
+    SLAM.SaveTrajectoryTUM(join_path(log_dir, "CameraTrajectory.txt"));
+    SLAM.SaveKeyFrameTrajectoryTUM(join_path(log_dir, "KeyFrameTrajectory.txt"));
 
     return 0;
 }

--- a/linux_slam/include/LoopClosing.h
+++ b/linux_slam/include/LoopClosing.h
@@ -143,7 +143,7 @@ protected:
     bool mbFixScale;
 
 
-    bool mnFullBAIdx;
+    int mnFullBAIdx;
 };
 
 } //namespace ORB_SLAM


### PR DESCRIPTION
## Summary
- keep linux_slam on the c++14 standard
- remove std::filesystem use in the SLAM tools
- add simple join_path and recursive mkdir helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q tests/test_utils.py tests/test_navigation_step.py`
- `bash linux_slam/build.sh` *(fails: missing third-party libs)*

------
https://chatgpt.com/codex/tasks/task_e_687b595024388325baaa261858ca664a