### PR TITLE
Set SLAM env vars for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Two helper applications live under `linux_slam/app`:
 
 - `offline_slam_evaluation` now accepts `--data-dir=DIR` to specify where RGB and depth images are loaded from.
 - `tcp_slam_server` reads log and flag locations from the command line or the environment variables `SLAM_LOG_DIR`, `SLAM_FLAG_DIR` and `SLAM_IMAGE_DIR`.
+- `launch_slam_backend` automatically exports these variables, pointing to the
+  repository's `flags/` and `logs/` folders, before starting `tcp_slam_server`.
 
 
 ---

--- a/tests/test_launch_all_helpers.py
+++ b/tests/test_launch_all_helpers.py
@@ -27,7 +27,12 @@ def test_launch_slam_backend_invokes_subprocess(monkeypatch):
     monkeypatch.setattr(subprocess, "Popen", lambda cmd, *a, **k: calls.append(cmd) or DummyProc())
     proc = lutils.launch_slam_backend("1.2.3.4", 6001)
     assert isinstance(proc, DummyProc)
-    assert calls and "POSE_RECEIVER_IP=1.2.3.4" in calls[0][-1]
+    assert calls
+    bash_cmd = calls[0][-1]
+    assert "POSE_RECEIVER_IP=1.2.3.4" in bash_cmd
+    assert "SLAM_FLAG_DIR=" in bash_cmd
+    assert "SLAM_LOG_DIR=" in bash_cmd
+    assert "SLAM_IMAGE_DIR=" in bash_cmd
 
 
 def test_record_slam_video_returns_path(monkeypatch):

--- a/uav/launch_utils.py
+++ b/uav/launch_utils.py
@@ -122,6 +122,9 @@ def launch_slam_backend(receiver_host: str, receiver_port: int) -> subprocess.Po
         "wsl", "bash", "-c",
         f"export POSE_RECEIVER_IP={receiver_host}; "
         f"export POSE_RECEIVER_PORT={receiver_port}; "
+        "export SLAM_FLAG_DIR=/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/flags; "
+        "export SLAM_LOG_DIR=/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/logs; "
+        "export SLAM_IMAGE_DIR=/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/logs/images; "
         "cd /mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/linux_slam/build && "
         "./app/tcp_slam_server ../Vocabulary/ORBvoc.txt ../app/rgbd_settings.yaml"
     ]


### PR DESCRIPTION
## Summary
- ensure `launch_slam_backend` exports SLAM directories before launching
- test that these variables appear in the command string
- document automatic export of SLAM env vars

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b82b477cc8325a4aa163077c3f24e