### PR TITLE
Fix tcp_slam_server build includes

### DIFF
--- a/linux_slam/app/tcp_slam_server.cpp
+++ b/linux_slam/app/tcp_slam_server.cpp
@@ -16,6 +16,8 @@
 #include <filesystem>
 #include <sys/stat.h>
 #include <cerrno>
+#include <arpa/inet.h>
+#include <sys/socket.h>
 #ifdef _WIN32
 #include <direct.h>
 #endif
@@ -36,6 +38,8 @@ using slam_server::g_log_file_path;
 using slam_server::log_event;
 using slam_server::get_feature_inliers;
 using slam_server::get_pose_covariance_with_inliers;
+using slam_server::recv_all;
+using slam_server::send_pose;
 
 // ------- Main function to set up the TCP server, receive images, and process them with ORB-SLAM2 -------
 // Simple cross-platform helpers

--- a/linux_slam/include/KeyFrame.h
+++ b/linux_slam/include/KeyFrame.h
@@ -22,13 +22,12 @@
 #define KEYFRAME_H
 
 #include "MapPoint.h"
-#include "/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/linux_slam/Thirdparty/DBoW2/DBoW2/BowVector.h"
+#include "Thirdparty/DBoW2/DBoW2/BowVector.h"
 #include "Thirdparty/DBoW2/DBoW2/FeatureVector.h"
 #include "ORBVocabulary.h"
 #include "ORBextractor.h"
 #include "Frame.h"
 #include "KeyFrameDatabase.h"
-#include "/mnt/h/Documents/AirSimExperiments/Hybrid_Navigation/linux_slam/Thirdparty/DBoW2/DBoW2/FeatureVector.h"
 
 
 

--- a/linux_slam/src/Sim3Solver.cc
+++ b/linux_slam/src/Sim3Solver.cc
@@ -214,7 +214,7 @@ cv::Mat Sim3Solver::find(vector<bool> &vbInliers12, int &nInliers)
 
 void Sim3Solver::ComputeCentroid(cv::Mat &P, cv::Mat &Pr, cv::Mat &C)
 {
-    cv::reduce(P,C,1,CV_REDUCE_SUM);
+    cv::reduce(P, C, 1, cv::REDUCE_SUM);
     C = C/P.cols;
 
     for(int i=0; i<P.cols; i++)


### PR DESCRIPTION
## Summary
- include socket headers for linux build
- expose recv_all/send_pose with `using` directives
- fix relative includes and reduce call
- compile tcp_slam_server via cmake

## Testing
- `pytest -k test_main_help -q`
- `cmake ..`
- `make tcp_slam_server -j8`

------
https://chatgpt.com/codex/tasks/task_e_687ba07e60148325b956bd37c12bb784