### PR TITLE
Use grayscale stereo images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository contains the implementation of a reactive obstacle avoidance sys
 - Logs flight data to CSV for post-flight analysis
 - Visualises 3D flight paths with interactive HTML output
 - Compatible with a custom stereo camera setup (`oakd_camera`)
+- Stereo images are streamed in grayscale to reduce processing overhead
 - Works with auto-launched AirSim simulation
 - Receives SLAM poses via a `PoseReceiver` that can be started and stopped programmatically
 - Integrated frontier-based exploration using SLAM map points

--- a/data_capture/capture_airsim_data.py
+++ b/data_capture/capture_airsim_data.py
@@ -38,13 +38,13 @@ def main() -> None:
         ])
 
         if len(responses) == 2:
-            # Left image
-            left_img = cv2.imdecode(responses[0].image_data_uint8, cv2.IMREAD_COLOR)
+            # Left image decoded directly as grayscale
+            left_img = cv2.imdecode(responses[0].image_data_uint8, cv2.IMREAD_GRAYSCALE)
             left_filename = os.path.join(output_dir, f"left_{i:05d}.png")
             cv2.imwrite(left_filename, left_img)
 
-            # Right image
-            right_img = cv2.imdecode(responses[1].image_data_uint8, cv2.IMREAD_COLOR)
+            # Right image decoded directly as grayscale
+            right_img = cv2.imdecode(responses[1].image_data_uint8, cv2.IMREAD_GRAYSCALE)
             right_filename = os.path.join(output_dir, f"right_{i:05d}.png")
             cv2.imwrite(right_filename, right_img)
             logger.info("Saved stereo pair %d", i)

--- a/linux_slam/app/tcp_slam_server.cpp
+++ b/linux_slam/app/tcp_slam_server.cpp
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
             uint32_t net_height, net_width, net_bytes;
             uint32_t rgb_height, rgb_width, rgb_bytes;
 
-            // --- Receive Left RGB Image ---
+            // --- Receive Left Grayscale Image ---
             char left_header[12];
             if (!recv_all(sock, left_header, 12)) break;
             memcpy(&net_height, left_header, 4);
@@ -209,28 +209,22 @@ int main(int argc, char **argv) {
             // Allocate buffer for left image
             vector<uchar> left_buffer(rgb_bytes);
             if (!recv_all(sock, (char*)left_buffer.data(), rgb_bytes)) break; // Receive the image data
-            cv::Mat left_rgb(rgb_height, rgb_width, CV_8UC3, left_buffer.data()); // Create Mat from buffer
-            if (left_rgb.empty() || left_rgb.rows != rgb_height || left_rgb.cols != rgb_width || left_rgb.type() != CV_8UC3) {
-                log_event("[ERROR] left_rgb invalid after construction! Skipping frame.");
+            cv::Mat left_gray(rgb_height, rgb_width, CV_8UC1, left_buffer.data()); // Create Mat from buffer
+            if (left_gray.empty() || left_gray.rows != rgb_height || left_gray.cols != rgb_width || left_gray.type() != CV_8UC1) {
+                log_event("[ERROR] left_gray invalid after construction! Skipping frame.");
                 continue;  // or break, depending on your policy
             }
 
-            log_event("Received Left image: height=" + std::to_string(left_rgb.rows) + ", width=" + std::to_string(left_rgb.cols));
-            imLeft = left_rgb.clone();  // save for snapshot + debug
-
-            if (!left_rgb.empty() && left_rgb.type() == CV_8UC3) { // Check if left_rgb is valid
-                cv::cvtColor(left_rgb, imLeftGray, cv::COLOR_RGB2GRAY);
-            } else {
-                log_event("[ERROR] Cannot convert left_rgb to grayscale: empty or wrong type.");
-                continue;
-            }
+            log_event("Received Left image: height=" + std::to_string(left_gray.rows) + ", width=" + std::to_string(left_gray.cols));
+            imLeftGray = left_gray.clone();
+            cv::cvtColor(left_gray, imLeft, cv::COLOR_GRAY2BGR); // for debug snapshots
 
             // --- DEBUG: Log right image properties ---
             {
                 std::ostringstream log;
                 log << "[DEBUG] Left image received: "
-                    << "height="<< left_rgb.rows
-                    << ", width=" << left_rgb.cols
+                    << "height="<< left_gray.rows
+                    << ", width=" << left_gray.cols
                     << ", expected bytes=" << rgb_bytes
                     << ", actual buffer size=" << left_buffer.size();
                 log_event(log.str());
@@ -254,7 +248,7 @@ int main(int argc, char **argv) {
                 log_event(csmsg.str());
             }
 
-            // --- Receive Right RGB Image ---
+            // --- Receive Right Grayscale Image ---
             char right_header[12];
             if (!recv_all(sock, right_header, 12)) break;
             memcpy(&net_height, right_header, 4);
@@ -277,21 +271,15 @@ int main(int argc, char **argv) {
 
             vector<uchar> right_buffer(rgb_bytes); // Allocate buffer for right image
             if (!recv_all(sock, (char*)right_buffer.data(), rgb_bytes)) break; // Receive the image data
-            cv::Mat right_rgb(rgb_height, rgb_width, CV_8UC3, right_buffer.data()); // Create Mat from buffer
-            if (right_rgb.empty() || right_rgb.rows != rgb_height || right_rgb.cols != rgb_width || right_rgb.type() != CV_8UC3) {
-                log_event("[ERROR] right_rgb invalid after construction! Skipping frame.");
+            cv::Mat right_gray(rgb_height, rgb_width, CV_8UC1, right_buffer.data()); // Create Mat from buffer
+            if (right_gray.empty() || right_gray.rows != rgb_height || right_gray.cols != rgb_width || right_gray.type() != CV_8UC1) {
+                log_event("[ERROR] right_gray invalid after construction! Skipping frame.");
                 continue;  // or break, depending on your policy
             }
 
-            log_event("Received Right image: height=" + std::to_string(right_rgb.rows) + ", width=" + std::to_string(right_rgb.cols));
-            imRight = right_rgb.clone();  // save for snapshot + debug
-            // Check if right_rgb is valid before converting
-            if (!right_rgb.empty() && right_rgb.type() == CV_8UC3) {
-                cv::cvtColor(right_rgb, imRightGray, cv::COLOR_RGB2GRAY);
-            } else {
-                log_event("[ERROR] Cannot convert right_rgb to grayscale: empty or wrong type.");
-                continue;
-            }
+            log_event("Received Right image: height=" + std::to_string(right_gray.rows) + ", width=" + std::to_string(right_gray.cols));
+            imRightGray = right_gray.clone();
+            cv::cvtColor(right_gray, imRight, cv::COLOR_GRAY2BGR); // for debug snapshots
 
             // --- DEBUG: Log right image properties ---
             {

--- a/slam_bridge/stream_airsim_image.py
+++ b/slam_bridge/stream_airsim_image.py
@@ -38,7 +38,7 @@ print(f"[stream_airsim_image.py] Logging configured. Writing to logs/stream_airs
 logger = logging.getLogger("stream_airsim_image")
 
 class ImageStreamer:
-    """Stream RGB + Depth or Stereo RGB images from AirSim to a TCP server."""
+    """Stream grayscale + depth or stereo grayscale images from AirSim to a TCP server."""
 
     def __init__(self, host: str, port: int, mode: str = "rgbd", retries: int = 10) -> None:
         self.host = host
@@ -94,10 +94,12 @@ class ImageStreamer:
             left = np.frombuffer(responses[0].image_data_uint8, dtype=np.uint8).reshape(
                 responses[0].height, responses[0].width, 3
             )
+            left = cv2.cvtColor(left, cv2.COLOR_BGR2GRAY)
             if hasattr(responses[1], "image_data_uint8"):
                 right = np.frombuffer(responses[1].image_data_uint8, dtype=np.uint8).reshape(
                     responses[1].height, responses[1].width, 3
                 )
+                right = cv2.cvtColor(right, cv2.COLOR_BGR2GRAY)
             else:
                 right = np.frombuffer(right_bytes, dtype=np.float32).reshape(
                     responses[1].height, responses[1].width

--- a/tests/test_stream_airsim_image.py
+++ b/tests/test_stream_airsim_image.py
@@ -3,6 +3,7 @@ import struct
 import threading
 import sys
 from types import SimpleNamespace
+import cv2
 
 import numpy as np
 
@@ -69,5 +70,6 @@ def test_image_streamer_sends_headers_and_data(monkeypatch):
     t.join(timeout=1)
     server.close()
 
-    assert results["rgb"] == (2, 2, rgb.tobytes())
+    expected_gray = cv2.cvtColor(rgb, cv2.COLOR_BGR2GRAY).tobytes()
+    assert results["rgb"] == (2, 2, expected_gray)
     assert results["depth"] == (2, 2, depth.tobytes())


### PR DESCRIPTION
## Summary
- stream stereo frames from AirSim in grayscale
- expect grayscale images on the SLAM side
- decode captured data as grayscale
- update perception loop for grayscale workflow
- adjust tests for grayscale streaming
- document grayscale pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba8154fa483259243ae948eb28c4f