### PR TITLE
Add SLAM bootstrap calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains the implementation of a reactive obstacle avoidance sys
 - Receives SLAM poses via a `PoseReceiver` that can be started and stopped programmatically
 - Integrated frontier-based exploration using SLAM map points
 - SLAM loop checks depth ahead and dodges obstacles before advancing
+- Performs an initial SLAM calibration manoeuvre after takeoff
 
 ---
 

--- a/tests/test_slam_nav_loop.py
+++ b/tests/test_slam_nav_loop.py
@@ -62,3 +62,63 @@ def test_slam_navigation_calls_navigator(monkeypatch):
 
     assert result == 'slam_nav'
     slam_mock.assert_called_once_with((0.0, 0.0, -2.0), (1.0, 2.0, -2.0))
+
+
+def test_slam_navigation_performs_bootstrap(monkeypatch):
+    """SLAM loop should run an initial calibration when duration > 0."""
+    airsim_stub = types.SimpleNamespace(
+        ImageRequest=object,
+        ImageType=object,
+        DrivetrainType=types.SimpleNamespace(ForwardOnly=1),
+        YawMode=lambda *a, **k: None,
+    )
+    monkeypatch.setitem(sys.modules, "airsim", airsim_stub)
+    nl = importlib.import_module("uav.nav_loop")
+    importlib.reload(nl)
+
+    import slam_bridge.slam_receiver as sr
+    import slam_bridge.frontier_detection as fd
+    monkeypatch.setattr(sr, "get_latest_pose", lambda: (0.0, 0.0, -2.0))
+    monkeypatch.setattr(sr, "get_pose_history", lambda: [])
+    monkeypatch.setattr(fd, "detect_frontiers", lambda m: nl.np.empty((0, 3)))
+    monkeypatch.setattr(nl, "is_obstacle_ahead", lambda *a, **k: (False, None))
+
+    boot_mock = mock.MagicMock()
+    monkeypatch.setattr(nl, "run_slam_bootstrap", boot_mock)
+    monkeypatch.setattr(nl.os.path, "exists", lambda p: True)
+
+    dummy_future = types.SimpleNamespace(join=lambda *a, **k: None)
+    client = types.SimpleNamespace(
+        simGetCollisionInfo=lambda: types.SimpleNamespace(has_collided=False),
+        moveByVelocityAsync=lambda *a, **k: dummy_future,
+        moveToPositionAsync=lambda *a, **k: dummy_future,
+        hoverAsync=lambda *a, **k: dummy_future,
+        landAsync=lambda *a, **k: dummy_future,
+    )
+
+    navigator = nl.Navigator(client)
+    monkeypatch.setattr(navigator, "slam_to_goal", lambda *a, **k: "slam_nav")
+
+    ctx = NavContext(
+        exit_flag=None,
+        param_refs=None,
+        tracker=None,
+        flow_history=None,
+        navigator=navigator,
+        state_history=deque(),
+        pos_history=deque(),
+        frame_queue=None,
+        video_thread=None,
+        out=None,
+        log_file=None,
+        log_buffer=[],
+        timestamp="",
+        start_time=0.0,
+        fps_list=[],
+        fourcc=None,
+    )
+    args = types.SimpleNamespace(max_duration=1, goal_x=1.0, goal_y=2.0, goal_z=-2.0)
+
+    nl.slam_navigation_loop(args, client, ctx)
+
+    boot_mock.assert_called_once()

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -348,9 +348,8 @@ def slam_navigation_loop(args, client, ctx):
     """
     Main navigation loop for SLAM-based navigation with basic obstacle avoidance.
     """
-    # After drone takeoff and camera ready
-    # run_slam_bootstrap(client, duration=6.0)  # you can tune this
-    # time.sleep(1.0)  # Let SLAM settle after bootstrap
+    # After drone takeoff and camera ready, perform an initial calibration
+    # sequence so SLAM has diverse motion before waypoint navigation.
 
     # logger.info("[SLAMNav] Starting SLAM navigation loop.")
 
@@ -372,6 +371,11 @@ def slam_navigation_loop(args, client, ctx):
     goal_y = getattr(args, "goal_y", 0) if hasattr(args, "goal_y") else 0
     goal_z = getattr(args, "goal_z", -2) if hasattr(args, "goal_z") else -2
     threshold = 0.5  # meters
+
+    # Perform an initial SLAM calibration manoeuvre before navigating.
+    if max_duration != 0:
+        run_slam_bootstrap(client, duration=6.0)
+        time.sleep(1.0)  # Allow SLAM to settle after calibration
 
     # Simplified execution path used by tests
     if max_duration == 0 and navigator is not None:


### PR DESCRIPTION
## Summary
- add a SLAM bootstrap manoeuvre before waypoint navigation
- document calibration step in the README
- verify the bootstrap is called in new unit test

## Testing
- `pip install -r requirements.txt` *(fails: airsim build requires numpy; psutil and pandas also missing)*
- `pytest -q` *(fails: missing optional dependencies such as pandas, psutil, scipy)*

------
https://chatgpt.com/codex/tasks/task_e_687d3fef746483259871a52d319dc529