### PR TITLE
Run SLAM bootstrap when tracking fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains the implementation of a reactive obstacle avoidance sys
 - Receives SLAM poses via a `PoseReceiver` that can be started and stopped programmatically
 - Integrated frontier-based exploration using SLAM map points
 - SLAM loop checks depth ahead and dodges obstacles before advancing
+- SLAM bootstrap routine automatically triggers whenever tracking is lost
 
 ---
 

--- a/tests/test_slam_nav_loop.py
+++ b/tests/test_slam_nav_loop.py
@@ -62,3 +62,79 @@ def test_slam_navigation_calls_navigator(monkeypatch):
 
     assert result == 'slam_nav'
     slam_mock.assert_called_once_with((0.0, 0.0, -2.0), (1.0, 2.0, -2.0))
+
+
+def test_slam_bootstrap_runs_when_tracking_lost(monkeypatch):
+    airsim_stub = types.SimpleNamespace(
+        ImageRequest=object,
+        ImageType=object,
+        DrivetrainType=types.SimpleNamespace(ForwardOnly=1),
+        YawMode=lambda *a, **k: None,
+    )
+    monkeypatch.setitem(sys.modules, "airsim", airsim_stub)
+    nl = importlib.import_module("uav.nav_loop")
+    importlib.reload(nl)
+
+    import slam_bridge.slam_receiver as sr
+    import slam_bridge.frontier_detection as fd
+    monkeypatch.setattr(sr, "get_latest_pose", lambda: (0.0, 0.0, -2.0))
+    monkeypatch.setattr(sr, "get_pose_history", lambda: [])
+    monkeypatch.setattr(fd, "detect_frontiers", lambda m: nl.np.empty((0, 3)))
+    monkeypatch.setattr(nl, "is_obstacle_ahead", lambda *a, **k: (False, None))
+
+    monkeypatch.setattr(nl, "is_slam_stable", lambda: False)
+    called = {}
+
+    def fake_boot(*a, **k):
+        called["run"] = True
+
+    monkeypatch.setattr(nl, "run_slam_bootstrap", fake_boot)
+    monkeypatch.setattr(nl.time, "sleep", lambda *_: None)
+
+    class Flag:
+        def __init__(self):
+            self.calls = 0
+
+        def is_set(self):
+            self.calls += 1
+            return self.calls > 1
+
+    dummy_future = types.SimpleNamespace(join=lambda *a, **k: None)
+    client = types.SimpleNamespace(
+        simGetCollisionInfo=lambda: types.SimpleNamespace(has_collided=False),
+        moveByVelocityAsync=lambda *a, **k: dummy_future,
+        moveToPositionAsync=lambda *a, **k: dummy_future,
+        hoverAsync=lambda *a, **k: dummy_future,
+        landAsync=lambda *a, **k: dummy_future,
+        simGetVehiclePose=lambda *a, **k: types.SimpleNamespace(
+            position=types.SimpleNamespace(x_val=0, y_val=0, z_val=-2)
+        ),
+    )
+
+    navigator = nl.Navigator(client)
+    monkeypatch.setattr(navigator, "slam_to_goal", lambda *a, **k: "slam_nav")
+
+    ctx = NavContext(
+        exit_flag=Flag(),
+        param_refs=None,
+        tracker=None,
+        flow_history=None,
+        navigator=navigator,
+        state_history=deque(),
+        pos_history=deque(),
+        frame_queue=None,
+        video_thread=None,
+        out=None,
+        log_file=None,
+        log_buffer=[],
+        timestamp="",
+        start_time=0.0,
+        fps_list=[],
+        fourcc=None,
+    )
+
+    args = types.SimpleNamespace(max_duration=1, goal_x=1.0, goal_y=2.0, goal_z=-2.0)
+
+    nl.slam_navigation_loop(args, client, ctx)
+
+    assert called.get("run") is True

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -399,17 +399,22 @@ def slam_navigation_loop(args, client, ctx):
 
             # --- Get the latest SLAM pose ---
             pose = get_latest_pose()
-            if pose is None: # No pose received, hover to recover
-                logger.warning("[SLAMNav] No pose received – hovering to recover.")
-                # client.hoverAsync().join()
+            if pose is None:  # No pose received, attempt recovery
+                logger.warning(
+                    "[SLAMNav] No pose received – running SLAM bootstrap."
+                )
+                run_slam_bootstrap(client, duration=6.0)
                 time.sleep(1.0)  # allow SLAM to reinitialize
                 continue
 
             # --- Check if SLAM is stable ---
             if not is_slam_stable():  # Check SLAM stability
-                logger.warning("[SLAMNav] SLAM is unstable. Pausing navigation.")
-                # client.hoverAsync().join()  # Pause the drone (hover)
-                continue  # Exit the loop or you can reset/restart SLAM if necessary
+                logger.warning(
+                    "[SLAMNav] SLAM is unstable. Running bootstrap recovery."
+                )
+                run_slam_bootstrap(client, duration=6.0)
+                time.sleep(1.0)  # Let SLAM settle after bootstrap
+                continue
             # else:
             #     logger.info("[SLAMNav] SLAM is stable. Continuing navigation.")
 


### PR DESCRIPTION
## Summary
- trigger SLAM bootstrap whenever tracking fails
- document automatic bootstrap in README
- test bootstrap trigger logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dd9d7fde08325978a49c35febd606