### PR TITLE
Support SLAM pose matrices

### DIFF
--- a/slam_bridge/pose_receiver.py
+++ b/slam_bridge/pose_receiver.py
@@ -96,6 +96,13 @@ class PoseReceiver:
                 logger.error(f"[PoseReceiver] Pose extraction failed: {e}")
                 return None
 
+    def get_latest_pose_matrix(self) -> Optional[List[List[float]]]:
+        """Return a copy of the latest received 3x4 pose matrix."""
+        with self._lock:
+            if self._latest_pose is None:
+                return None
+            return [row[:] for row in self._latest_pose]
+
     def get_latest_inliers(self) -> Optional[int]:
         with self._lock:
             return self._latest_inliers

--- a/slam_bridge/slam_receiver.py
+++ b/slam_bridge/slam_receiver.py
@@ -136,6 +136,9 @@ class SlamReceiver:
 
     def get_latest_pose(self) -> Optional[Tuple[float, float, float]]:
         return self.receiver.get_latest_pose()
+
+    def get_latest_pose_matrix(self):
+        return self.receiver.get_latest_pose_matrix()
     
     def get_pose_history(self):
         return self.receiver.get_pose_history()
@@ -180,6 +183,12 @@ def get_latest_pose() -> Optional[Tuple[float, float, float]]:
         logger.debug("[slam_receiver] Latest pose matrix: %s", matrix)
         if matrix is not None and isinstance(matrix, (list, tuple)) and len(matrix) == 3:
             return tuple(matrix)
+    return None
+
+
+def get_latest_pose_matrix():
+    if _manager is not None:
+        return _manager.get_latest_pose_matrix()
     return None
 
 

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -238,3 +238,22 @@ def test_navigation_skips_actions_during_grace_after_blind_forward(monkeypatch):
 
     assert result[0] == "none"
     assert client.moveByVelocityZAsync.call_count == 1
+
+
+def test_slam_to_goal_accepts_pose_matrix(monkeypatch):
+    client = DummyClient()
+    nav = Navigator(client)
+
+    from uav import config
+    monkeypatch.setattr(config, "SLAM_YAW_OFFSET", 10.0, raising=False)
+
+    pose = [
+        [0, -1, 0, 5.0],
+        [1, 0, 0, 3.0],
+        [0, 0, 1, -2.0],
+    ]
+    nav.slam_to_goal(pose, (6.0, 3.0, -2.0), max_speed=1.0)
+
+    name, args, kwargs, fut = client.calls[-1]
+    assert name == "moveByVelocityAsync"
+    assert abs(kwargs["yaw_mode"].yaw_or_rate - 100.0) < 1e-3

--- a/tests/test_pose_receiver.py
+++ b/tests/test_pose_receiver.py
@@ -31,3 +31,17 @@ def test_receives_pose():
     receiver.stop()
     assert pose == (3.0, 7.0, 11.0)
 
+
+def test_receives_pose_matrix():
+    receiver = PoseReceiver(host="127.0.0.1", port=0)
+    receiver.start()
+    port = receiver.port
+    time.sleep(0.1)
+    matrix_values = list(range(12))
+    _send_pose("127.0.0.1", port, matrix_values)
+    time.sleep(0.1)
+    matrix = receiver.get_latest_pose_matrix()
+    receiver.stop()
+    expected = [matrix_values[i * 4 : (i + 1) * 4] for i in range(3)]
+    assert matrix == expected
+

--- a/tests/test_slam_nav_loop.py
+++ b/tests/test_slam_nav_loop.py
@@ -20,7 +20,8 @@ def test_slam_navigation_calls_navigator(monkeypatch):
 
     import slam_bridge.slam_receiver as sr
     import slam_bridge.frontier_detection as fd
-    monkeypatch.setattr(sr, 'get_latest_pose', lambda: (0.0, 0.0, -2.0))
+    sample_matrix = [[1, 0, 0, 0.0], [0, 1, 0, 0.0], [0, 0, 1, -2.0]]
+    monkeypatch.setattr(sr, 'get_latest_pose_matrix', lambda: sample_matrix)
     monkeypatch.setattr(sr, 'get_pose_history', lambda: [])
     monkeypatch.setattr(fd, 'detect_frontiers', lambda m: nl.np.empty((0, 3)))
     monkeypatch.setattr(nl, 'is_obstacle_ahead', lambda *a, **k: (False, None))
@@ -61,7 +62,7 @@ def test_slam_navigation_calls_navigator(monkeypatch):
     result = nl.slam_navigation_loop(args, client, ctx)
 
     assert result == 'slam_nav'
-    slam_mock.assert_called_once_with((0.0, 0.0, -2.0), (1.0, 2.0, -2.0))
+    slam_mock.assert_called_once_with(sample_matrix, (1.0, 2.0, -2.0))
 
 
 def test_slam_navigation_performs_bootstrap(monkeypatch):
@@ -78,7 +79,8 @@ def test_slam_navigation_performs_bootstrap(monkeypatch):
 
     import slam_bridge.slam_receiver as sr
     import slam_bridge.frontier_detection as fd
-    monkeypatch.setattr(sr, "get_latest_pose", lambda: (0.0, 0.0, -2.0))
+    sample_matrix = [[1, 0, 0, 0.0], [0, 1, 0, 0.0], [0, 0, 1, -2.0]]
+    monkeypatch.setattr(sr, "get_latest_pose_matrix", lambda: sample_matrix)
     monkeypatch.setattr(sr, "get_pose_history", lambda: [])
     monkeypatch.setattr(fd, "detect_frontiers", lambda m: nl.np.empty((0, 3)))
     monkeypatch.setattr(nl, "is_obstacle_ahead", lambda *a, **k: (False, None))
@@ -137,8 +139,8 @@ def test_slam_navigation_reinitialises_when_tracking_lost(monkeypatch):
 
     import slam_bridge.slam_receiver as sr
     import slam_bridge.frontier_detection as fd
-    poses = [None, (0.0, 0.0, -2.0)]
-    monkeypatch.setattr(sr, "get_latest_pose", lambda: poses.pop(0) if poses else (0.0, 0.0, -2.0))
+    poses = [None, [[1,0,0,0.0],[0,1,0,0.0],[0,0,1,-2.0]]]
+    monkeypatch.setattr(sr, "get_latest_pose_matrix", lambda: poses.pop(0) if poses else [[1,0,0,0.0],[0,1,0,0.0],[0,0,1,-2.0]])
     monkeypatch.setattr(sr, "get_pose_history", lambda: [])
     monkeypatch.setattr(fd, "detect_frontiers", lambda m: nl.np.empty((0, 3)))
 

--- a/uav/config.py
+++ b/uav/config.py
@@ -14,6 +14,7 @@ VIDEO_FPS = 8.0
 VIDEO_SIZE = (1280, 720)
 VIDEO_OUTPUT = 'flow_output.avi'
 FLOW_STD_MAX = 50.0
+SLAM_YAW_OFFSET = 0.0
 
 def load_app_config(config_path: str = "config.ini"):
     """Load application config from an INI file."""

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -363,7 +363,7 @@ def slam_navigation_loop(args, client, ctx):
 
     # logger.info("[SLAMNav] Starting SLAM navigation loop.")
 
-    from slam_bridge.slam_receiver import get_latest_pose, get_pose_history
+    from slam_bridge.slam_receiver import get_latest_pose_matrix, get_pose_history
     from slam_bridge.frontier_detection import detect_frontiers  
 
     # --- Incorporate exit_flag from ctx for GUI stop button ---
@@ -389,8 +389,8 @@ def slam_navigation_loop(args, client, ctx):
 
     # Simplified execution path used by tests
     if max_duration == 0 and navigator is not None:
-        pose = get_latest_pose()
-        return navigator.slam_to_goal(pose, (goal_x, goal_y, goal_z))
+        pose_mat = get_latest_pose_matrix()
+        return navigator.slam_to_goal(pose_mat, (goal_x, goal_y, goal_z))
 
     # --- Define waypoints for SLAM navigation ---
     waypoints = [
@@ -415,7 +415,7 @@ def slam_navigation_loop(args, client, ctx):
             # If SLAM is unstable, reinitialise it
             # This is a basic stability check that can be improved.
             # Need to ensure that this check is continuously performed during the waypoint navigation. 
-            pose = get_latest_pose()
+            pose = get_latest_pose_matrix()
             if pose is None or not is_slam_stable():
                 logger.warning(
                     "[SLAMNav] SLAM tracking lost. Attempting reinitialisation."
@@ -423,7 +423,7 @@ def slam_navigation_loop(args, client, ctx):
                 while True:
                     run_slam_bootstrap(client, duration=4.0)
                     time.sleep(1.0)
-                    pose = get_latest_pose()
+                    pose = get_latest_pose_matrix()
                     if pose is not None and is_slam_stable():
                         logger.info(
                             "[SLAMNav] SLAM reinitialised. Resuming navigation."
@@ -439,7 +439,7 @@ def slam_navigation_loop(args, client, ctx):
                         return last_action
                 continue
 
-            x_slam, y_slam, z_slam = pose
+            x_slam, y_slam, z_slam = pose[0][3], pose[1][3], pose[2][3]
             x, y, z = x_slam, y_slam, -z_slam  # Adjust z for AirSim
             # logger.info(f"[SLAMNav] Received pose: x={x:.2f}, y={y:.2f}, z={z:.2f}")
             # logger.debug("[SLAM Pose] x=%.2f, y=%.2f, z=%.2f", x, y, z)

--- a/uav/navigation.py
+++ b/uav/navigation.py
@@ -4,6 +4,7 @@ import time
 import math
 import logging
 import airsim
+from uav import config
 
 logger = logging.getLogger(__name__)
 
@@ -163,15 +164,37 @@ class Navigator:
     
     def slam_to_goal(self, pose, goal, max_speed=1.5, threshold=0.5,
                      settle_time=1.0, velocity_threshold=0.1):
-        """Move toward ``goal`` using the provided SLAM ``pose``."""
+        """Move toward ``goal`` using the provided SLAM ``pose``.
+
+        ``pose`` may be a translation tuple ``(x, y, z)`` or a 3x4 pose
+        matrix. When a matrix is provided the yaw angle is extracted from the
+        rotation part and adjusted by ``config.SLAM_YAW_OFFSET``.
+        """
 
         state = self.client.getMultirotorState()
 
+        yaw = 0.0
         if pose is None:
             pos = state.kinematics_estimated.position
             x, y, z = pos.x_val, pos.y_val, pos.z_val
         else:
-            x, y, z = pose
+            if (
+                isinstance(pose, (list, tuple))
+                and len(pose) == 3
+                and not isinstance(pose[0], (list, tuple))
+            ):
+                x, y, z = pose
+            else:
+                # Assume pose is a 3x4 matrix-like object
+                x = pose[0][3]
+                y = pose[1][3]
+                z = pose[2][3]
+                # Extract yaw from rotation matrix and apply offset
+                try:
+                    yaw = math.degrees(math.atan2(pose[1][0], pose[0][0]))
+                except Exception:
+                    yaw = 0.0
+                yaw += getattr(config, "SLAM_YAW_OFFSET", 0.0)
 
         gx, gy, gz = goal
         dx = gx - x
@@ -198,5 +221,12 @@ class Navigator:
             return "airsim_stop"
         vx, vy = dx / dist * max_speed, dy / dist * max_speed
         vz = 0.0  # Don't change altitude, just hold current Z
-        self.client.moveByVelocityAsync(vx, vy, vz, duration=1, vehicle_name="UAV")
-        return f"airsim_nav vx={vx:.2f} vy={vy:.2f} vz={vz:.2f} dist={dist:.2f}"
+        self.client.moveByVelocityAsync(
+            vx,
+            vy,
+            vz,
+            duration=1,
+            vehicle_name="UAV",
+            yaw_mode=airsim.YawMode(False, yaw),
+        )
+        return f"airsim_nav vx={vx:.2f} vy={vy:.2f} vz={vz:.2f} dist={dist:.2f} yaw={yaw:.2f}"


### PR DESCRIPTION
## Summary
- expose `get_latest_pose_matrix` in pose receiver and slam receiver
- allow Navigator.slam_to_goal to accept a 3x4 pose matrix and correct yaw
- keep yaw offset configurable via `SLAM_YAW_OFFSET`
- make nav loop request pose matrices and pass them to Navigator
- test full pose matrix retrieval and update SLAM nav loop tests
- ensure pose tuples aren't confused with matrices
- cover new behavior in navigator tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687de28f61bc832599d3d644518850e3