### PR TITLE
Add 3D obstacle drawing and tests

### DIFF
--- a/tests/test_visualize_flight.py
+++ b/tests/test_visualize_flight.py
@@ -73,3 +73,18 @@ def test_find_alignment_marker_success_and_failure():
 
     with pytest.raises(ValueError):
         vis.find_alignment_marker([], marker_name="missing")
+
+
+def test_obstacles_add_traces():
+    telemetry = vis.np.array([[0, 0, 0], [1, 1, 1]])
+
+    no_obs_fig = vis.build_plot(telemetry, [], vis.np.array([0, 0, 0]))
+    base_count = len(no_obs_fig.data)
+
+    obstacles = [
+        {"name": "Box1", "location": [0, 0, 0], "dimensions": [1, 1, 1], "rotation": [0, 0, 0]},
+    ]
+
+    fig = vis.build_plot(telemetry, obstacles, vis.np.array([0, 0, 0]))
+
+    assert len(fig.data) > base_count


### PR DESCRIPTION
## Summary
- implement `draw_box` with a `Mesh3d` representation
- append box traces in `build_plot`
- verify obstacles add traces when visualising flights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e0e587afc832590b86880bca47feb