### PR TITLE
Fix SLAM stability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ tracking is reliable. The default thresholds are defined in
 `uav.slam_utils` as `COVARIANCE_THRESHOLD = 1.0` and
 `MIN_INLIERS_THRESHOLD = 50`. They can be overridden on the command line using
 `--slam-covariance-threshold` and `--slam-inlier-threshold` or in the `[slam]`
-section of `config.ini`.
+section of `config.ini`. If either covariance or inlier data is unavailable the
+system now treats SLAM tracking as unstable and triggers reinitialisation.
 
 Example quick start:
 

--- a/tests/test_slam_utils.py
+++ b/tests/test_slam_utils.py
@@ -71,3 +71,12 @@ def test_is_slam_stable_respects_inlier_threshold(monkeypatch):
     assert su.is_slam_stable() is False
     assert su.is_slam_stable(inlier_threshold=20) is True
 
+
+def test_is_slam_stable_handles_missing_data(monkeypatch):
+    su = _load_module(monkeypatch)
+    monkeypatch.setattr(su.slam_receiver, "get_latest_pose", lambda: (0, 0, 0))
+    monkeypatch.setattr(su.slam_receiver, "get_latest_covariance", lambda: None)
+    monkeypatch.setattr(su.slam_receiver, "get_latest_inliers", lambda: None)
+
+    assert su.is_slam_stable() is False
+

--- a/uav/slam_utils.py
+++ b/uav/slam_utils.py
@@ -46,9 +46,9 @@ def is_slam_stable(
 
     if pose_covariance is None or inliers is None:
         logger.warning(
-            "[SLAM] Covariance or inlier data unavailable. Assuming stable."
+            "[SLAM] Covariance or inlier data unavailable. SLAM is unstable."
         )
-        return True
+        return False
     
     # Check if pose covariance is within acceptable limits
     if pose_covariance > covariance_threshold:


### PR DESCRIPTION
## Summary
- treat missing SLAM covariance or inliers as instability
- clarify SLAM stability behaviour in README
- test for missing data handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e126350dc8325960aa40e1235175a