### PR TITLE
Add flight log analysis CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ setup_logging("run.log")  # also prints to stdout
 - 3D trajectory plots are saved in `analysis/` as interactive `.html` files
 - Runtime messages are configured via `uav.logging_config.setup_logging` using the standard `logging` module
 - SLAM pose and feature debugging is printed to stdout and stored in `logs/`
+- Generate HTML summaries with `analyze-flight LOG.csv`
 
 ---
 

--- a/analysis/analyze.py
+++ b/analysis/analyze.py
@@ -1,0 +1,80 @@
+import argparse
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import pandas as pd
+from plotly.subplots import make_subplots
+import plotly.graph_objects as go
+
+from .flight_review import parse_log
+from .visualise_flight import build_plot
+
+
+def analyse_logs(log_paths: List[str], output: str) -> None:
+    """Parse ``log_paths`` and write an interactive HTML report."""
+    dfs = []
+    stats = []
+    for p in log_paths:
+        stats.append(parse_log(p))
+        dfs.append(pd.read_csv(p))
+    df = pd.concat(dfs, ignore_index=True)
+
+    path = df[["pos_x", "pos_y", "pos_z"]].to_numpy(dtype=float)
+    fig3d = build_plot(path, [], np.array([0, 0, 0]), log=df, colour_by="time")
+
+    fig = make_subplots(
+        rows=2,
+        cols=2,
+        specs=[[{"type": "scene"}, {"type": "xy"}], [{"type": "xy", "colspan": 2}, None]],
+        subplot_titles=("Trajectory", "Flow Magnitudes", "Speed / Performance"),
+    )
+
+    for trace in fig3d.data:
+        fig.add_trace(trace, row=1, col=1)
+
+    if {"time", "flow_left", "flow_center", "flow_right"}.issubset(df.columns):
+        fig.add_trace(go.Scatter(x=df["time"], y=df["flow_left"], name="flow_left"), row=1, col=2)
+        fig.add_trace(go.Scatter(x=df["time"], y=df["flow_center"], name="flow_center"), row=1, col=2)
+        fig.add_trace(go.Scatter(x=df["time"], y=df["flow_right"], name="flow_right"), row=1, col=2)
+
+    if "time" in df.columns and "speed" in df.columns:
+        fig.add_trace(go.Scatter(x=df["time"], y=df["speed"], name="speed"), row=2, col=1)
+    if "time" in df.columns and "cpu_percent" in df.columns:
+        fig.add_trace(go.Scatter(x=df["time"], y=df["cpu_percent"], name="cpu %"), row=2, col=1)
+    if "time" in df.columns and "mem_mb" in df.columns:
+        fig.add_trace(go.Scatter(x=df["time"], y=df["mem_mb"], name="mem MB"), row=2, col=1)
+
+    fig.update_layout(height=600, width=900)
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    fig.write_html(output)
+
+    total_frames = sum(s["frames"] for s in stats)
+    total_collisions = sum(s["collisions"] for s in stats)
+    total_distance = sum(s["distance"] for s in stats)
+    fps_vals = [s["fps_avg"] for s in stats if not np.isnan(s["fps_avg"])]
+    loop_vals = [s["loop_avg"] for s in stats if not np.isnan(s["loop_avg"])]
+
+    print(f"Frames: {total_frames}")
+    print(f"Collisions: {total_collisions}")
+    print(f"Distance travelled: {total_distance:.2f} m")
+    if fps_vals:
+        print(f"Average FPS: {np.mean(fps_vals):.2f}")
+    if loop_vals:
+        print(f"Average loop time: {np.mean(loop_vals):.3f}s")
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze flight logs")
+    parser.add_argument("logs", nargs="+", help="CSV log files")
+    parser.add_argument("-o", "--output", default="analysis/flight_view.html", help="Output HTML file")
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> None:
+    args = parse_args(argv)
+    analyse_logs(args.logs, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'console_scripts': [
             'hybrid-nav=main:main',
             'airsim-streamer=slam_bridge.stream_airsim_image:main',
+            'analyze-flight=analysis.analyze:main',
         ],
     },
 )

--- a/tests/test_analyze_flight.py
+++ b/tests/test_analyze_flight.py
@@ -1,0 +1,32 @@
+import subprocess
+import sys
+import pandas as pd
+
+
+def test_analyze_cli_produces_html(tmp_path):
+    df = pd.DataFrame({
+        "pos_x": [0, 1, 2],
+        "pos_y": [0, 0, 0],
+        "pos_z": [0, 0, 0],
+        "time": [0, 1, 2],
+        "flow_left": [0.1, 0.2, 0.3],
+        "flow_center": [0.2, 0.3, 0.4],
+        "flow_right": [0.3, 0.4, 0.5],
+        "speed": [1.0, 1.0, 1.0],
+        "fps": [10, 10, 10],
+        "loop_s": [0.1, 0.1, 0.1],
+        "state": ["resume", "resume", "resume"],
+    })
+    log_path = tmp_path / "log.csv"
+    df.to_csv(log_path, index=False)
+    out_path = tmp_path / "view.html"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.analyze", str(log_path), "-o", str(out_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert out_path.exists()
+    content = out_path.read_text().lower()
+    assert "<html" in content


### PR DESCRIPTION
## Summary
- add `analysis/analyze.py` for parsing logs and plotting summary
- register `analyze-flight` console entry point
- document usage in README
- test CLI for HTML output

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e3a90e6988325be5269301c62569f