### PR TITLE
Add CPU and memory stats to nav logs

### DIFF
--- a/tests/test_log_columns.py
+++ b/tests/test_log_columns.py
@@ -1,0 +1,39 @@
+import importlib
+import sys
+import types
+
+import tests.conftest  # ensure stubs loaded
+
+
+def test_setup_environment_header_includes_perf(monkeypatch, tmp_path):
+    airsim_stub = types.SimpleNamespace(ImageRequest=object, ImageType=object)
+    monkeypatch.setitem(sys.modules, "airsim", airsim_stub)
+    nl = importlib.import_module("uav.nav_loop")
+    importlib.reload(nl)
+
+    monkeypatch.setattr(nl, "start_video_writer_thread", lambda *a, **k: types.SimpleNamespace(join=lambda: None))
+    monkeypatch.setattr(nl, "retain_recent_logs", lambda *a, **k: None)
+    monkeypatch.setattr(nl, "retain_recent_files", lambda *a, **k: None)
+    monkeypatch.setattr(nl, "retain_recent_views", lambda *a, **k: None)
+    monkeypatch.setattr(nl, "init_client", lambda *a, **k: None)
+    monkeypatch.setattr(nl, "OpticalFlowTracker", lambda *a, **k: object())
+    monkeypatch.setattr(nl, "FlowHistory", lambda *a, **k: object())
+    monkeypatch.setattr(nl, "Navigator", lambda *a, **k: object())
+    monkeypatch.setattr(nl.cv2, "VideoWriter_fourcc", lambda *a: 0)
+    monkeypatch.setattr(nl.cv2, "VideoWriter", lambda *a, **k: types.SimpleNamespace(release=lambda: None))
+
+    args = types.SimpleNamespace(goal_x=0.0, max_duration=1)
+    dummy_future = types.SimpleNamespace(join=lambda *a, **k: None)
+    client = types.SimpleNamespace(
+        listVehicles=lambda: [],
+        takeoffAsync=lambda: dummy_future,
+        moveToPositionAsync=lambda *a, **k: dummy_future,
+    )
+    monkeypatch.chdir(tmp_path)
+    ctx = nl.setup_environment(args, client)
+    ctx.log_file.close()
+    log_file = next((tmp_path / "flow_logs").glob("full_log_*.csv"))
+    header = log_file.read_text().splitlines()[0]
+    assert "cpu_percent" in header
+    assert "memory_rss" in header
+

--- a/uav/logging_helpers.py
+++ b/uav/logging_helpers.py
@@ -10,6 +10,7 @@ from uav import config
 from uav.video_utils import start_video_writer_thread
 from uav.logging_utils import format_log_line
 from uav.utils import retain_recent_logs, retain_recent_files, get_drone_state
+from uav.performance import get_cpu_percent, get_memory_info
 from uav.overlay import draw_overlay
 from uav.perception import FlowHistory
 from uav.navigation import Navigator
@@ -99,6 +100,8 @@ def write_frame_output(
     loop_elapsed = time.time() - loop_start
     actual_fps = 1 / max(loop_elapsed, 1e-6)
     loop_start = time.time()
+    cpu_percent = get_cpu_percent()
+    mem_rss = get_memory_info().rss
     fps_list.append(actual_fps)
     log_line = format_log_line(
         frame_count,
@@ -129,6 +132,8 @@ def write_frame_output(
         decode_s,
         processing_s,
         loop_elapsed,
+        cpu_percent,
+        mem_rss,
     )
     log_frame_data(log_file, log_buffer, log_line)
     logger.debug("Actual FPS: %.2f", actual_fps)
@@ -175,7 +180,7 @@ def handle_reset(client, ctx, frame_count):
             "brake_thres,dodge_thres,probe_req,fps,"
             "state,collided,obstacle,side_safe,"
             "pos_x,pos_y,pos_z,yaw,speed,"
-            "time,features,simgetimage_s,decode_s,processing_s,loop_s\n"
+            "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss\n"
         )
     log_file = open(log_path, 'a')
     ctx.log_file = log_file

--- a/uav/logging_utils.py
+++ b/uav/logging_utils.py
@@ -30,6 +30,8 @@ def format_log_line(
     decode_s,
     processing_s,
     loop_elapsed,
+    cpu_percent,
+    mem_rss,
 ) -> str:
     """Return a formatted CSV line for logging navigation state."""
 
@@ -41,5 +43,6 @@ def format_log_line(
         f"{state_str},{collided},{obstacle_detected},{int(side_safe)},"
         f"{pos.x_val:.2f},{pos.y_val:.2f},{pos.z_val:.2f},{yaw:.2f},{speed:.2f},"
         f"{time_now:.2f},{len(good_old)},"
-        f"{simgetimage_s:.3f},{decode_s:.3f},{processing_s:.3f},{loop_elapsed:.3f}\n"
+        f"{simgetimage_s:.3f},{decode_s:.3f},{processing_s:.3f},{loop_elapsed:.3f},"
+        f"{cpu_percent:.1f},{mem_rss}\n"
     )

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -68,7 +68,7 @@ def setup_environment(args, client):
         "brake_thres,dodge_thres,probe_req,fps,"
         "state,collided,obstacle,side_safe,"
         "pos_x,pos_y,pos_z,yaw,speed,"
-        "time,features,simgetimage_s,decode_s,processing_s,loop_s\n"
+        "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss\n"
     )
     retain_recent_logs("flow_logs")
     retain_recent_logs("logs")


### PR DESCRIPTION
## Summary
- log CPU percentage and memory RSS on each frame
- include new columns in generated CSV headers
- test that header includes the performance columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e3a9f81888325a2edad61a942320c