### PR TITLE
Add performance plotting tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ setup_logging("run.log")  # also prints to stdout
 - Generate HTML summaries with `analyze-flight LOG.csv`
 - Run `python -m slam_bridge.slam_plotter` to record SLAM poses and generate a trajectory HTML file
 - Visualise a flight path with `python -m analysis.visualise_flight OUTPUT.html --log LOG.csv --obstacles OBSTACLES.json`
+- Plot CPU and memory usage with `python -m analysis.performance_plots LOG.csv -o OUT.html`
 
 ---
 

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -3,10 +3,12 @@
 from .flight_review import parse_log, align_path
 from .summarise_runs import summarise_log
 from . import visualise_flight
+from .performance_plots import plot_performance
 
 __all__ = [
     "parse_log",
     "align_path",
     "summarise_log",
     "visualise_flight",
+    "plot_performance",
 ]

--- a/analysis/performance_plots.py
+++ b/analysis/performance_plots.py
@@ -1,0 +1,64 @@
+"""Plot CPU and memory usage from a flight log."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+from plotly.subplots import make_subplots
+import plotly.graph_objects as go
+
+
+def build_plot(df: pd.DataFrame) -> go.Figure:
+    """Return a Plotly figure showing CPU and memory usage.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing ``cpu_percent`` and ``memory_rss`` columns and
+        either ``time`` or ``frame`` for the x-axis.
+    """
+    if "time" in df.columns:
+        x = df["time"]
+        x_title = "Time (s)"
+    else:
+        x = df.index
+        x_title = "Frame"
+
+    cpu = df.get("cpu_percent", pd.Series(dtype=float))
+    mem = df.get("memory_rss", pd.Series(dtype=float)) / (1024 * 1024)
+
+    fig = make_subplots(specs=[[{"secondary_y": True}]])
+    fig.add_trace(go.Scatter(x=x, y=cpu, name="CPU %"), secondary_y=False)
+    fig.add_trace(go.Scatter(x=x, y=mem, name="Memory MB"), secondary_y=True)
+
+    fig.update_layout(xaxis_title=x_title)
+    fig.update_yaxes(title_text="CPU %", secondary_y=False)
+    fig.update_yaxes(title_text="Memory (MB)", secondary_y=True)
+    return fig
+
+
+def plot_performance(log_path: str, out_path: str) -> None:
+    """Read ``log_path`` CSV and write an interactive HTML plot to ``out_path``."""
+    df = pd.read_csv(log_path)
+    fig = build_plot(df)
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.write_html(out)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Plot performance metrics from a log")
+    parser.add_argument("log", help="CSV log file")
+    parser.add_argument("-o", "--output", default="analysis/performance.html", help="Output HTML file")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    plot_performance(args.log, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_performance_plots.py
+++ b/tests/test_performance_plots.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+import pandas as pd
+
+
+def test_performance_cli_generates_html(tmp_path):
+    df = pd.DataFrame({
+        'time': [0, 1, 2],
+        'cpu_percent': [10, 20, 30],
+        'memory_rss': [1_000_000, 2_000_000, 3_000_000],
+    })
+    log_path = tmp_path / 'perf.csv'
+    df.to_csv(log_path, index=False)
+    out_path = tmp_path / 'perf.html'
+
+    result = subprocess.run([
+        sys.executable,
+        '-m',
+        'analysis.performance_plots',
+        str(log_path),
+        '-o',
+        str(out_path),
+    ], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert out_path.exists()
+    assert '<html' in out_path.read_text().lower()


### PR DESCRIPTION
## Summary
- add script to plot CPU and memory usage from CSV logs
- expose new helper in analysis package
- document the new script in the README
- test that the new CLI can generate an HTML output

## Testing
- `pytest tests/test_performance_plots.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e96f86ffc8325ad00afbd3574d8da