### PR TITLE
Implement graceful shutdown wait logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ monitors to coordinate the run. Selecting a mode and pressing *Launch
 Simulation* writes `nav_mode.flag`. Once all systems report ready, clicking
 *Start Navigation* creates `start_nav.flag` which unblocks the navigation loop.
 Pressing the stop button touches `stop.flag` so the running process can safely
-land and exit.
+land and exit. The launcher now waits up to `GRACE_TIME` seconds for
+`main.py` to terminate after creating this flag before forcefully killing any
+remaining processes.
 
 ### SLAM Utilities
 


### PR DESCRIPTION
## Summary
- add GRACE_TIME and request_shutdown helper in `launch_all.py`
- wait for main process gracefully before killing in `Launcher.shutdown`
- add tests for graceful shutdown timing
- document graceful shutdown in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f33a9929883258cdb5c2ace94678f