### PR TITLE
Fix logging config docstring example

### DIFF
--- a/uav/logging_config.py
+++ b/uav/logging_config.py
@@ -30,7 +30,7 @@ def setup_logging(
         Log to dedicated file:
             setup_logging(
                 log_file="launch.log",
-                module_files={"slam_bridge": "slam_output.log"}
+                module_logs={"slam_bridge": "slam_output.log"}
             )
             logger = logging.getLogger("slam_bridge")
 


### PR DESCRIPTION
## Summary
- fix example usage of `setup_logging`
- run tests

## Testing
- `pytest -q` *(fails: 12 failed, 62 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f39d00e808325bd4bf5a345b47136