### PR TITLE
Add context manager for PoseReceiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains the implementation of a reactive obstacle avoidance sys
 - Compatible with a custom stereo camera setup (`oakd_camera`)
 - Stereo images are streamed in grayscale to reduce processing overhead
 - Works with auto-launched AirSim simulation
-- Receives SLAM poses via a `PoseReceiver` that can be started and stopped programmatically
+- Receives SLAM poses via a `PoseReceiver` that can be started and stopped programmatically or used as a context manager for automatic cleanup
 - SLAM poses now include orientation and are corrected by `Navigator.slam_to_goal` using `config.SLAM_YAW_OFFSET`
 - Integrated frontier-based exploration using SLAM map points
 - SLAM loop checks depth ahead and dodges obstacles before advancing

--- a/slam_bridge/pose_receiver.py
+++ b/slam_bridge/pose_receiver.py
@@ -26,6 +26,16 @@ class PoseReceiver:
         self._history = deque(maxlen=history_size)
         self._conn: Optional[socket.socket] = None
 
+    def __enter__(self):
+        """Start the receiver when entering a context."""
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        """Ensure the receiver is stopped when leaving a context."""
+        self.stop()
+        return False
+
 
     def start(self) -> None:
         if self._thread and self._thread.is_alive():
@@ -75,6 +85,7 @@ class PoseReceiver:
             self._thread.join()
             if self._thread.is_alive():
                 logger.warning("[PoseReceiver] Thread did not exit cleanly after stop().")
+            self._thread = None
 
     def get_latest_pose(self) -> Optional[Tuple[float, float, float]]:
         """

--- a/slam_bridge/testposereceiver.py
+++ b/slam_bridge/testposereceiver.py
@@ -5,5 +5,5 @@ import logging
 logging.basicConfig(level=logging.INFO)
 
 # Start PoseReceiver on the default host (0.0.0.0) and port (6001)
-receiver = PoseReceiver(host='0.0.0.0', port=6001)
-receiver.start()
+with PoseReceiver(host='0.0.0.0', port=6001) as receiver:
+    logging.info("PoseReceiver running...")

--- a/tests/test_pose_receiver.py
+++ b/tests/test_pose_receiver.py
@@ -12,36 +12,38 @@ def _send_pose(host, port, matrix):
 
 
 def test_start_and_stop():
-    receiver = PoseReceiver(host="127.0.0.1", port=0)
-    receiver.start()
-    assert receiver._thread is not None and receiver._thread.is_alive()
-    assert receiver.port != 0
-    receiver.stop()
-    assert not receiver._thread.is_alive()
+    with PoseReceiver(host="127.0.0.1", port=0) as receiver:
+        assert receiver._thread is not None and receiver._thread.is_alive()
+        assert receiver.port != 0
+    assert receiver._thread is None or not receiver._thread.is_alive()
 
 
 def test_receives_pose():
-    receiver = PoseReceiver(host="127.0.0.1", port=0)
-    receiver.start()
-    port = receiver.port
-    time.sleep(0.1)
-    _send_pose("127.0.0.1", port, list(range(12)))
-    time.sleep(0.1)
-    pose = receiver.get_latest_pose()
-    receiver.stop()
+    with PoseReceiver(host="127.0.0.1", port=0) as receiver:
+        port = receiver.port
+        time.sleep(0.1)
+        _send_pose("127.0.0.1", port, list(range(12)))
+        time.sleep(0.1)
+        pose = receiver.get_latest_pose()
     assert pose == (3.0, 7.0, 11.0)
 
 
 def test_receives_pose_matrix():
-    receiver = PoseReceiver(host="127.0.0.1", port=0)
-    receiver.start()
-    port = receiver.port
-    time.sleep(0.1)
-    matrix_values = list(range(12))
-    _send_pose("127.0.0.1", port, matrix_values)
-    time.sleep(0.1)
-    matrix = receiver.get_latest_pose_matrix()
-    receiver.stop()
+    with PoseReceiver(host="127.0.0.1", port=0) as receiver:
+        port = receiver.port
+        time.sleep(0.1)
+        matrix_values = list(range(12))
+        _send_pose("127.0.0.1", port, matrix_values)
+        time.sleep(0.1)
+        matrix = receiver.get_latest_pose_matrix()
     expected = [matrix_values[i * 4 : (i + 1) * 4] for i in range(3)]
     assert matrix == expected
+
+
+def test_context_manager_cleans_up():
+    with PoseReceiver(host="127.0.0.1", port=0) as receiver:
+        assert receiver._thread is not None and receiver._thread.is_alive()
+        time.sleep(0.1)
+    assert receiver._sock is None
+    assert receiver._thread is None or not receiver._thread.is_alive()
 


### PR DESCRIPTION
## Summary
- support `with PoseReceiver()` for automatic start/stop
- ensure thread reset in `stop`
- switch example script and tests to use context manager
- document the context manager usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: tests require unavailable dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f78869c8883258fd118a69a414d31