### PR TITLE
Remove SETTINGS_PATH constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ pip install -e .
 
 4. Build your Unreal map and generate a packaged `.exe` (e.g. `Blocks.exe`).
 
-5. Edit `config.ini` to point to your AirSim `settings.json`, UE4 executables and the SLAM networking details. The `[network]` section controls the IP and port used by the image streamer and pose receiver. The streamer also reads `SLAM_SERVER_HOST`, `SLAM_SERVER_PORT` and `CONNECT_RETRIES` from the environment (or command line) so these values can be overridden without editing the config file.
+5. Edit `config.ini` to point to your AirSim `settings.json`, UE4 executables and the SLAM networking details. The `[network]` section controls the IP and port used by the image streamer and pose receiver. The streamer also reads `SLAM_SERVER_HOST`, `SLAM_SERVER_PORT` and `CONNECT_RETRIES` from the environment (or command line) so these values can be overridden without editing the config file. The path under `[paths]` provides the default for `--settings-path`.
 
 6. Run the system:
    ```bash
@@ -144,7 +144,7 @@ The `hybrid-nav` entry point exposes several options:
 | `--manual-nudge` | Enable manual nudge at frame 5 for testing |
 | `--map {reactive, deliberative, hybrid}` | Which map to load |
 | `--ue4-path PATH` | Override the path to the Unreal Engine executable |
-| `--settings-path PATH` | Path to the AirSim `settings.json` file |
+| `--settings-path PATH` | Path to the AirSim `settings.json` file (default from `config.ini`) |
 | `--config FILE` | Path to configuration file (default: `config.ini`) |
 | `--goal-x INT` | Distance from start to goal on the X axis |
 | `--max-duration INT` | Maximum simulation duration in seconds |

--- a/main.py
+++ b/main.py
@@ -44,14 +44,16 @@ logger.info(
 flags_dir = Path("flags")
 flags_dir.mkdir(exist_ok=True)
 START_FLAG_PATH = flags_dir / "start_nav.flag"
-SETTINGS_PATH = r"C:\Users\Jacob\OneDrive\Documents\AirSim\settings.json"
 
 
 def get_settings_path(args, config):
+    """Resolve the path to the AirSim settings file."""
+    if args.settings_path:
+        return args.settings_path
     try:
-        return args.settings_path or config.get("paths", "settings")
+        return config.get("paths", "settings")
     except Exception:
-        return SETTINGS_PATH
+        return None
 
 def wait_for_nav_trigger():
     logger.info("[INFO] Waiting for navigation start flag...")


### PR DESCRIPTION
## Summary
- drop obsolete SETTINGS_PATH constant
- fall back to config.ini for settings path
- mention config.ini default in README

## Testing
- `pytest -q` *(fails: test_launch_all_main_flag_flow, test_shutdown_force_kills_after_timeout, test_navigation_skips_actions_during_grace_after_blind_forward, test_slam_navigation_calls_navigator, test_slam_navigation_performs_bootstrap, test_slam_bootstrap_runs_when_tracking_lost, test_is_obstacle_ahead_detects_obstacle, test_is_obstacle_ahead_handles_missing_image, test_image_streamer_sends_headers_and_data, test_build_plot_returns_figure, test_obstacles_add_traces, test_colour_and_orientation)*

------
https://chatgpt.com/codex/tasks/task_e_687f7897bfd08325ad98f8b928a65e64