### PR TITLE
Add obstacle condition flags to logs

### DIFF
--- a/tests/test_log_columns.py
+++ b/tests/test_log_columns.py
@@ -36,4 +36,8 @@ def test_setup_environment_header_includes_perf(monkeypatch, tmp_path):
     header = log_file.read_text().splitlines()[0]
     assert "cpu_percent" in header
     assert "memory_rss" in header
+    assert "sudden_rise" in header
+    assert "center_blocked" in header
+    assert "combination_flow" in header
+    assert "minimum_flow" in header
 

--- a/uav/logging_helpers.py
+++ b/uav/logging_helpers.py
@@ -69,6 +69,10 @@ def write_frame_output(
     decode_s,
     processing_s,
     flow_std,
+    sudden_rise,
+    center_blocked,
+    combination_flow,
+    minimum_flow,
 ):
     """Overlay telemetry, write video, and log the frame."""
     pos, yaw, speed = get_drone_state(client)
@@ -134,6 +138,10 @@ def write_frame_output(
         loop_elapsed,
         cpu_percent,
         mem_rss,
+        sudden_rise,
+        center_blocked,
+        combination_flow,
+        minimum_flow,
     )
     log_frame_data(log_file, log_buffer, log_line)
     logger.debug("Actual FPS: %.2f", actual_fps)
@@ -180,7 +188,8 @@ def handle_reset(client, ctx, frame_count):
             "brake_thres,dodge_thres,probe_req,fps,"
             "state,collided,obstacle,side_safe,"
             "pos_x,pos_y,pos_z,yaw,speed,"
-            "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss\n"
+            "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss,"
+            "sudden_rise,center_blocked,combination_flow,minimum_flow\n"
         )
     log_file = open(log_path, 'a')
     ctx.log_file = log_file

--- a/uav/logging_utils.py
+++ b/uav/logging_utils.py
@@ -32,6 +32,10 @@ def format_log_line(
     loop_elapsed,
     cpu_percent,
     mem_rss,
+    sudden_rise,
+    center_blocked,
+    combination_flow,
+    minimum_flow,
 ) -> str:
     """Return a formatted CSV line for logging navigation state."""
 
@@ -44,5 +48,6 @@ def format_log_line(
         f"{pos.x_val:.2f},{pos.y_val:.2f},{pos.z_val:.2f},{yaw:.2f},{speed:.2f},"
         f"{time_now:.2f},{len(good_old)},"
         f"{simgetimage_s:.3f},{decode_s:.3f},{processing_s:.3f},{loop_elapsed:.3f},"
-        f"{cpu_percent:.1f},{mem_rss}\n"
+        f"{cpu_percent:.1f},{mem_rss},"
+        f"{int(sudden_rise)},{int(center_blocked)},{int(combination_flow)},{int(minimum_flow)}\n"
     )

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -69,7 +69,8 @@ def setup_environment(args, client):
         "brake_thres,dodge_thres,probe_req,fps,"
         "state,collided,obstacle,side_safe,"
         "pos_x,pos_y,pos_z,yaw,speed,"
-        "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss\n"
+        "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss,"
+        "sudden_rise,center_blocked,combination_flow,minimum_flow\n"
     )
     retain_recent_logs("flow_logs")
     retain_recent_logs("logs")
@@ -251,6 +252,10 @@ def log_and_record_frame(
         brake_thres,
         dodge_thres,
         probe_req,
+        sudden_rise,
+        center_blocked,
+        combination_flow,
+        minimum_flow,
     ) = nav_decision
     return write_frame_output(
         client,
@@ -287,6 +292,10 @@ def log_and_record_frame(
         decode_s,
         processing_s,
         flow_std,
+        sudden_rise,
+        center_blocked,
+        combination_flow,
+        minimum_flow,
     )
 
 def navigation_loop(args, client, ctx):

--- a/uav/navigation_core.py
+++ b/uav/navigation_core.py
@@ -386,9 +386,9 @@ def navigation_step(
 
     Returns
     -------
-    Tuple[str, int, bool, float, float, float]
+    Tuple[str, int, bool, float, float, float, bool, bool, bool, bool]
         Tuple containing the selected state string, obstacle flag, side safety
-        flag and dynamic thresholds.
+        flag, dynamic thresholds and detailed obstacle condition flags.
     """
     state_str = "none"
     brake_thres = 0.0
@@ -412,7 +412,18 @@ def navigation_step(
     logger.debug("Flow Magnitudes — L: %.2f, C: %.2f, R: %.2f", smooth_L, smooth_C, smooth_R)
 
     if handle_grace_period(time_now, navigator, frame_queue, vis_img, param_refs):
-        return state_str, obstacle_detected, side_safe, brake_thres, dodge_thres, probe_req
+        return (
+            state_str,
+            obstacle_detected,
+            side_safe,
+            brake_thres,
+            dodge_thres,
+            probe_req,
+            sudden_rise,
+            center_blocked,
+            combination_flow,
+            minimum_flow,
+        )
 
     navigator.just_resumed = False
 
@@ -483,7 +494,18 @@ def navigation_step(
 
     pos, yaw, speed = get_drone_state(client)
     brake_thres, dodge_thres = compute_thresholds(speed)
-    return state_str, obstacle_detected, side_safe, brake_thres, dodge_thres, probe_req
+    return (
+        state_str,
+        obstacle_detected,
+        side_safe,
+        brake_thres,
+        dodge_thres,
+        probe_req,
+        sudden_rise,
+        center_blocked,
+        combination_flow,
+        minimum_flow,
+    )
 
 
 def apply_navigation_decision(
@@ -517,7 +539,7 @@ def apply_navigation_decision(
 
     Returns
     -------
-    Tuple[str, int, bool, float, float, float]
+    Tuple[str, int, bool, float, float, float, bool, bool, bool, bool]
         Output of :func:`navigation_step`.
     """
     return navigation_step(


### PR DESCRIPTION
## Summary
- extend log headers with new obstacle condition columns
- carry condition flags through navigation logic
- update format_log_line to output the flags
- update tests for new columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fdae7fb8c832598cc65ab03114f79