### PR TITLE
Implement minimum flow filter and horizontal segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repository contains the implementation of a reactive obstacle avoidance sys
 
 - Real-time optical flow tracking using Lucas-Kanade method
 - Zone-based obstacle avoidance using vector summation
+- Configurable minimum flow filter focuses on foreground motion
+- Flow analysis now includes vertical and horizontal image segments
 - Modular helpers for obstacle detection and side safety
 - Logs flight data to CSV for post-flight analysis
 - The pose comparison CSV now records the current navigation state

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -56,7 +56,11 @@ def setup_environment(args, client):
     lk_params = dict(winSize=(15, 15), maxLevel=2, criteria=(cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT, 10, 0.03))
     
     # Add minimum flow magnitude filter to tracker initialization
-    tracker = OpticalFlowTracker(lk_params, feature_params)
+    tracker = OpticalFlowTracker(
+        lk_params,
+        feature_params,
+        config.MIN_FLOW_MAG,
+    )
     
     flow_history, navigator = FlowHistory(), Navigator(client)
 
@@ -186,6 +190,12 @@ def update_navigation_state(client, args, ctx, data, frame_count, time_now, max_
         left_count,
         center_count,
         right_count,
+        top_mag,
+        mid_mag,
+        bottom_mag,
+        top_count,
+        mid_count,
+        bottom_count,
         in_grace,
     ) = processed
     prev_state = ctx.param_refs.state[0]
@@ -249,6 +259,12 @@ def log_and_record_frame(
         left_count,
         center_count,
         right_count,
+        top_mag,
+        mid_mag,
+        bottom_mag,
+        top_count,
+        mid_count,
+        bottom_count,
         in_grace,
     ) = processed
     (

--- a/uav/perception.py
+++ b/uav/perception.py
@@ -55,7 +55,7 @@ class FlowHistory:
 class OpticalFlowTracker:
     """Track sparse optical flow features between frames."""
 
-    def __init__(self, lk_params: Dict, feature_params: Dict, min_flow_mag: float = None) -> None:
+    def __init__(self, lk_params: Dict, feature_params: Dict, min_flow_mag: float | None = None) -> None:
         """Initialize tracker with Lucas-Kanade and feature parameters.
 
         Args:
@@ -64,6 +64,9 @@ class OpticalFlowTracker:
         """
         self.lk_params: Dict = lk_params
         self.feature_params: Dict = feature_params
+        self.min_flow_mag: float = (
+            config.MIN_FLOW_MAG if min_flow_mag is None else float(min_flow_mag)
+        )
         self.prev_gray: Optional[np.ndarray] = None
         self.prev_pts: Optional[np.ndarray] = None
         self.prev_time: float = time.time()
@@ -134,8 +137,16 @@ class OpticalFlowTracker:
         if len(good_old) == 0:
             return np.array([]), np.array([]), 0.0
         
-        flow_vectors = good_new - good_old        
+        flow_vectors = good_new - good_old
         magnitudes = np.linalg.norm(flow_vectors, axis=1) / dt
-        flow_std = np.std(magnitudes)
-        
+
+        # Filter out low-magnitude background flow
+        if self.min_flow_mag is not None:
+            valid_mask = magnitudes >= self.min_flow_mag
+            good_old = good_old[valid_mask]
+            flow_vectors = flow_vectors[valid_mask]
+            magnitudes = magnitudes[valid_mask]
+
+        flow_std = float(np.std(magnitudes)) if len(magnitudes) else 0.0
+
         return good_old, flow_vectors, flow_std

--- a/uav/perception_loop.py
+++ b/uav/perception_loop.py
@@ -138,6 +138,12 @@ def process_perception_data(
         left_count,
         center_count,
         right_count,
+        top_mag,
+        mid_mag,
+        bottom_mag,
+        top_count,
+        mid_count,
+        bottom_count,
     ) = compute_region_stats(magnitudes, good_old, image_width)
 
     flow_history.update(left_mag, center_mag, right_mag)
@@ -186,5 +192,11 @@ def process_perception_data(
         left_count,
         center_count,
         right_count,
+        top_mag,
+        mid_mag,
+        bottom_mag,
+        top_count,
+        mid_count,
+        bottom_count,
         in_grace,
     )

--- a/uav/scoring.py
+++ b/uav/scoring.py
@@ -5,33 +5,59 @@ import numpy as np
 def compute_region_stats(
     magnitudes: np.ndarray, good_old: np.ndarray, image_width: int
 ) -> tuple:
-    """Return average flow magnitude in left/center/right/probe regions."""
+    """Return average flow magnitude in spatial regions."""
 
     h = 720  # Fixed height based on 1280x720 resolution
     good_old = good_old.reshape(-1, 2)
     x_coords = good_old[:, 0]
     y_coords = good_old[:, 1]
 
-    # Define bands
+    # Define vertical bands
     left_mask = x_coords < image_width // 3
     center_mask = (x_coords >= image_width // 3) & (x_coords < 2 * image_width // 3)
     right_mask = x_coords >= 2 * image_width // 3
-    probe_band = y_coords < h // 3
+
+    # Horizontal bands
+    top_mask = y_coords < h // 3
+    mid_mask = (y_coords >= h // 3) & (y_coords < 2 * h // 3)
+    bottom_mask = y_coords >= 2 * h // 3
+
+    # Probe band uses top-center region
+    probe_band = center_mask & top_mask
 
     # Magnitudes
     left_mag = np.mean(magnitudes[left_mask]) if np.any(left_mask) else 0
     center_mag = np.mean(magnitudes[center_mask]) if np.any(center_mask) else 0
     right_mag = np.mean(magnitudes[right_mask]) if np.any(right_mask) else 0
-    probe_mag = np.mean(magnitudes[center_mask & probe_band]) if np.any(center_mask & probe_band) else 0
-    probe_count = int(np.sum(center_mask & probe_band))
+    probe_mag = np.mean(magnitudes[probe_band]) if np.any(probe_band) else 0
+    probe_count = int(np.sum(probe_band))
+
+    top_mag = np.mean(magnitudes[top_mask]) if np.any(top_mask) else 0
+    mid_mag = np.mean(magnitudes[mid_mask]) if np.any(mid_mask) else 0
+    bottom_mag = np.mean(magnitudes[bottom_mask]) if np.any(bottom_mask) else 0
 
     # Feature counts
     left_count = int(np.sum(left_mask))
     center_count = int(np.sum(center_mask))
     right_count = int(np.sum(right_mask))
 
+    top_count = int(np.sum(top_mask))
+    mid_count = int(np.sum(mid_mask))
+    bottom_count = int(np.sum(bottom_mask))
+
     return (
-        left_mag, center_mag, right_mag,
-        probe_mag, probe_count,
-        left_count, center_count, right_count
+        left_mag,
+        center_mag,
+        right_mag,
+        probe_mag,
+        probe_count,
+        left_count,
+        center_count,
+        right_count,
+        top_mag,
+        mid_mag,
+        bottom_mag,
+        top_count,
+        mid_count,
+        bottom_count,
     )


### PR DESCRIPTION
## Summary
- filter optical flow vectors below `config.MIN_FLOW_MAG`
- expose `MIN_FLOW_MAG` when creating the `OpticalFlowTracker`
- compute horizontal segment metrics in `compute_region_stats`
- update perception loop and navigation loop for new return values
- document new features in the README

## Testing
- `pip install pandas==1.5.3 psutil==5.9.0 plotly==5.19.0 scipy==1.10.0`
- `pytest -q` *(fails: AssertionError: 'slam_ready.flag' in ['airsim_ready.flag'])*

------
https://chatgpt.com/codex/tasks/task_e_688095a24f948325b076a64ddb4f6b53