### PR TITLE
Fix perception response check

### DIFF
--- a/analysis/visualise_flight.py
+++ b/analysis/visualise_flight.py
@@ -139,7 +139,10 @@ def build_plot(
         line=line_opts,
     )
     path_trace = go.Scatter3d(**path_kwargs)
-    setattr(path_trace, "kwargs", path_kwargs)
+    # plotly objects forbid setting arbitrary attributes via normal setattr
+    # when validation is enabled. Use object.__setattr__ so tests can inspect
+    # the original kwargs without triggering a validation error.
+    object.__setattr__(path_trace, "kwargs", path_kwargs)
     traces = [path_trace]
 
     for obs in obstacles:
@@ -177,7 +180,7 @@ def build_plot(
                 line=dict(color="orange"),
             )
             orient_trace = go.Scatter3d(**orient_kwargs)
-            setattr(orient_trace, "kwargs", orient_kwargs)
+            object.__setattr__(orient_trace, "kwargs", orient_kwargs)
             traces.append(orient_trace)
         except Exception:
             pass

--- a/uav/perception_loop.py
+++ b/uav/perception_loop.py
@@ -50,8 +50,7 @@ def start_perception_thread(ctx):
             flow_resp, left_resp, right_resp = responses[0], responses[1], responses[2]
             # Check if the response is valid
             if (
-                left_resp.width == 0
-                or flow_resp.width == 0
+                flow_resp.width == 0
                 or flow_resp.height == 0
                 or len(flow_resp.image_data_uint8) == 0
                 or left_resp.width == 0


### PR DESCRIPTION
## Summary
- allow plotly visualisation to store kwargs by bypassing attribute validation
- guard simGetImages response without redundant width check

## Testing
- `pytest -q` *(fails: tests/test_launch_all_main.py::test_launch_all_main_flag_flow, tests/test_launch_all_main.py::test_shutdown_force_kills_after_timeout, tests/test_nav_loop_helpers.py::test_detect_obstacle, tests/test_navigation_step.py::test_brake_when_side_flow_high, tests/test_navigation_step.py::test_blind_forward_with_low_flow, tests/test_navigator.py::test_dodge_left_sets_flags_and_calls, tests/test_navigator.py::test_ambiguous_dodge_forces_lower_flow_side, tests/test_navigator.py::test_navigation_skips_actions_during_grace_after_blind_forward, tests/test_slam_nav_loop.py::test_slam_navigation_calls_navigator, tests/test_slam_nav_loop.py::test_slam_nav_uses_airsim_pose, tests/test_slam_nav_loop.py::test_slam_navigation_performs_bootstrap, tests/test_slam_nav_loop.py::test_slam_bootstrap_runs_when_tracking_lost, tests/test_slam_utils.py::test_is_obstacle_ahead_detects_obstacle, tests/test_slam_utils.py::test_is_obstacle_ahead_handles_missing_image, tests/test_stream_airsim_image.py::test_image_streamer_sends_headers_and_data, tests/test_visualize_flight.py::test_build_plot_returns_figure, tests/test_visualize_flight.py::test_obstacles_add_traces, tests/test_visualize_flight.py::test_colour_and_orientation)*

------
https://chatgpt.com/codex/tasks/task_e_6880f824fd8883258988a8619c0f2047