### PR TITLE
Add performance helper tests

### DIFF
--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,18 @@
+import types
+
+from uav import performance
+
+
+def test_performance_helpers(monkeypatch):
+    cpu_val = 42.5
+    mem_info = types.SimpleNamespace(rss=123456)
+
+    monkeypatch.setattr(performance.psutil, "cpu_percent", lambda: cpu_val)
+    monkeypatch.setattr(
+        performance.psutil,
+        "Process",
+        lambda: types.SimpleNamespace(memory_info=lambda: mem_info),
+    )
+
+    assert performance.get_cpu_percent() == cpu_val
+    assert performance.get_memory_info() is mem_info


### PR DESCRIPTION
## Summary
- add a simple performance helper test using monkeypatch
- invoke analysis scripts via subprocess in `finalise_files`
- handle missing `taskkill` in launcher shutdown

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 22 failed, 56 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688101f3d0488325b5173a28f323e333