### PR TITLE
Add goal-y cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The `hybrid-nav` entry point exposes several options:
 | `--settings-path PATH` | Path to the AirSim `settings.json` file (default from `config.ini`) |
 | `--config FILE` | Path to configuration file (default: `config.ini`) |
 | `--goal-x INT` | Distance from start to goal on the X axis |
+| `--goal-y INT` | Distance from start to goal on the Y axis |
 | `--max-duration INT` | Maximum simulation duration in seconds |
 | `--nav-mode {slam, reactive}` | Navigation mode to run |
 | `--slam-server-host HOST` | SLAM server IP or hostname |

--- a/tests/test_cleanup_helpers.py
+++ b/tests/test_cleanup_helpers.py
@@ -3,7 +3,7 @@ import sys
 import types
 import queue
 import io
-import types
+from pathlib import Path
 
 import pytest
 
@@ -99,10 +99,13 @@ def test_finalise_files(monkeypatch, tmp_path):
     monkeypatch.setattr('uav.slam_utils.generate_pose_comparison_plot', lambda: calls.append('pose_plot'))
     nl.STOP_FLAG_PATH = tmp_path/'stop.flag'
     nl.STOP_FLAG_PATH.write_text('1')
+    log_dir = Path('flow_logs')
+    log_dir.mkdir(exist_ok=True)
+    (log_dir / 'full_log_1234.csv').write_text('dummy')
     ctx = types.SimpleNamespace(timestamp='1234')
     nl.finalise_files(ctx)
-    assert any('analysis.visualise_flight' in ' '.join(c) for c in calls)
-    assert any('analysis.analyse' in ' '.join(c) for c in calls)
+    assert any('analysis/visualise_flight.py' in ' '.join(c) for c in calls)
+    assert any('analysis/analyse.py' in ' '.join(c) for c in calls)
     assert 'pose_plot' in calls
     assert not nl.STOP_FLAG_PATH.exists()
 
@@ -117,6 +120,9 @@ def test_finalise_files_calledprocesserror(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr('uav.slam_utils.generate_pose_comparison_plot', lambda: None)
 
     nl.STOP_FLAG_PATH = tmp_path / 'stop.flag'
+    log_dir = Path('flow_logs')
+    log_dir.mkdir(exist_ok=True)
+    (log_dir / 'full_log_ts.csv').write_text('dummy')
     ctx = types.SimpleNamespace(timestamp='ts')
 
     with caplog.at_level(nl.logging.ERROR):

--- a/tests/test_launch_all_main.py
+++ b/tests/test_launch_all_main.py
@@ -69,6 +69,7 @@ def test_launch_all_main_flag_flow(tmp_path, monkeypatch):
         slam_receiver_host="127.0.0.1",
         slam_receiver_port=6001,
         config="none",
+        goal_y=0,
     )
     monkeypatch.setattr(launch_all, "parse_args", lambda: args)
     monkeypatch.setattr(launch_all, "load_app_config", lambda p: configparser.ConfigParser())
@@ -146,6 +147,7 @@ def test_stop_flag_waits_for_main(tmp_path, monkeypatch):
         slam_receiver_host="127.0.0.1",
         slam_receiver_port=6001,
         config="none",
+        goal_y=0,
     )
     monkeypatch.setattr(launch_all, "parse_args", lambda: args)
     monkeypatch.setattr(launch_all, "load_app_config", lambda p: configparser.ConfigParser())

--- a/tests/test_log_columns.py
+++ b/tests/test_log_columns.py
@@ -22,7 +22,7 @@ def test_setup_environment_header_includes_perf(monkeypatch, tmp_path):
     monkeypatch.setattr(nl.cv2, "VideoWriter_fourcc", lambda *a: 0)
     monkeypatch.setattr(nl.cv2, "VideoWriter", lambda *a, **k: types.SimpleNamespace(release=lambda: None))
 
-    args = types.SimpleNamespace(goal_x=0.0, max_duration=1)
+    args = types.SimpleNamespace(goal_x=0.0, goal_y=0.0, max_duration=1)
     dummy_future = types.SimpleNamespace(join=lambda *a, **k: None)
     client = types.SimpleNamespace(
         listVehicles=lambda: [],

--- a/uav/cli.py
+++ b/uav/cli.py
@@ -8,6 +8,7 @@ def parse_args():
     parser.add_argument("--settings-path", default=None, help="Path to AirSim settings.json")
     parser.add_argument("--config", default="config.ini", help="Path to config file with default paths")
     parser.add_argument("--goal-x", type=int, default=29, help="Distance from start to goal (X coordinate)")
+    parser.add_argument("--goal-y", type=int, default=0, help="Distance from start to goal (Y coordinate)")
     parser.add_argument("--max-duration", type=int, default=60, help="Maximum simulation duration in seconds")
     parser.add_argument(
         "--nav-mode",

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -349,7 +349,12 @@ def navigation_loop(args, client, ctx):
 
     max_flow_mag = config.MAX_FLOW_MAG
     max_duration = args.max_duration
-    goal_x, goal_y = args.goal_x, config.GOAL_Y
+    goal_x = getattr(args, "goal_x", None)
+    if goal_x is None:
+        goal_x = config.GOAL_X
+    goal_y = getattr(args, "goal_y", None)
+    if goal_y is None:
+        goal_y = config.GOAL_Y
     frame_count = 0
     frame_duration = 1.0 / config.TARGET_FPS
 


### PR DESCRIPTION
## Summary
- expose `--goal-y` CLI argument
- pull goal coordinates from CLI or config
- update CLI table in docs
- adjust tests for the new argument and updated analysis behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 21 failed, 56 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6881020860b48325ae650e57b9d3f56d