### PR TITLE
Add landing when goal reached

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository contains the implementation of a reactive obstacle avoidance sys
 - Integrated frontier-based exploration using SLAM map points
 - SLAM loop checks depth ahead and dodges obstacles before advancing
 - Performs an initial SLAM calibration manoeuvre after takeoff that returns the drone to face forward
+- Automatically lands the drone when the final goal position is reached
 
 SLAM poses contain both position and orientation. When a pose matrix is passed to `Navigator.slam_to_goal`, the yaw angle is extracted and corrected by `config.SLAM_YAW_OFFSET` before commanding the drone.
 

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -159,6 +159,9 @@ def check_exit_conditions(client, ctx, time_now, max_duration, goal_x, goal_y):
     pos_goal, _, _ = get_drone_state(client)
     if abs(pos_goal.x_val - goal_x) < 0.5 and abs(pos_goal.y_val - goal_y) < 0.5:
         logger.info("Goal reached — landing.")
+        if getattr(ctx, "param_refs", None):
+            ctx.param_refs.state[0] = "landing"
+        ctx.exit_flag.set()
         return True
     return False
 
@@ -515,6 +518,15 @@ def slam_navigation_loop(args, client, ctx, config=None, pose_source="slam"):
             history = get_pose_history()
             map_pts = np.array([[m[0][3], m[1][3], m[2][3]] for _, m in history], dtype=float)
             frontiers = detect_frontiers(map_pts)
+
+            # Detect if final waypoint has been reached
+            curr_goal = waypoints[current_waypoint_index]
+            dist_to_goal = np.sqrt((x - curr_goal[0]) ** 2 + (y - curr_goal[1]) ** 2)
+            if current_waypoint_index == len(waypoints) - 1 and dist_to_goal < threshold:
+                logger.info("[SLAMNav] Final goal reached — landing.")
+                if ctx is not None and getattr(ctx, "param_refs", None):
+                    ctx.param_refs.state[0] = "landing"
+                break
 
             (goal_x, goal_y, goal_z), current_waypoint_index, dist = handle_waypoint_progress(
                 x, y, waypoints, current_waypoint_index, threshold


### PR DESCRIPTION
## Summary
- mark navigation state as landing when goal reached in reactive nav loop
- detect final waypoint in SLAM loop and land
- document new landing behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68810946acf883259c0d64f500a16124