### PR TITLE
Add output directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The `hybrid-nav` entry point exposes several options:
 | `--slam-covariance-threshold FLOAT` | Covariance threshold for SLAM stability |
 | `--slam-inlier-threshold INT` | Minimum inliers for SLAM stability |
 | `--log-timestamp STR` | Timestamp used to sync logging across modules |
+| `--output-dir DIR` | Directory where logs and analysis files are saved |
 
 ### SLAM Stability
 
@@ -173,7 +174,9 @@ system now treats SLAM tracking as unstable and triggers reinitialisation.
 Example quick start:
 
 ```bash
-hybrid-nav --ue4-path /path/to/Blocks.exe --settings-path ~/Documents/AirSim/settings.json --nav-mode slam
+hybrid-nav --ue4-path /path/to/Blocks.exe \
+  --settings-path ~/Documents/AirSim/settings.json \
+  --nav-mode slam --output-dir ./run1
 ```
 
 ### GUI and Flag Files
@@ -211,10 +214,10 @@ from uav.logging_config import setup_logging
 setup_logging("run.log")  # also prints to stdout
 ```
 
-- Flight logs are stored in `flow_logs/` as `.csv`
+- Flight logs are stored in `flow_logs/` as `.csv` (use `--output-dir` to change the base folder)
 - 3D trajectory plots are saved in `analysis/` as interactive `.html` files
 - Runtime messages are configured via `uav.logging_config.setup_logging` using the standard `logging` module
-- SLAM pose and feature debugging is printed to stdout and stored in `logs/`
+- SLAM pose and feature debugging is printed to stdout and stored in `logs/` (affected by `--output-dir`)
 - Generate HTML summaries with `analyse-flight LOG.csv`
 - Run `python -m slam_bridge.slam_plotter` to record SLAM poses and generate a trajectory HTML file
 - Visualise a flight path with `python -m analysis.visualise_flight OUTPUT.html --log LOG.csv --obstacles OBSTACLES.json`
@@ -235,8 +238,8 @@ ReactiveOptical_Flow/
 │   ├── navigation.py        # Control logic
 │   ├── utils.py             # Helper functions
 │   └── __init__.py
-├── flow_logs/               # CSV logs of motion + control
-├── analysis/                # 3D path visualisations
+├── flow_logs/               # CSV logs of motion + control (or `OUT/flow_logs` when using `--output-dir`)
+├── analysis/                # 3D path visualisations (or `OUT/analysis`)
 ```
 
 ---

--- a/tests/test_cleanup_helpers.py
+++ b/tests/test_cleanup_helpers.py
@@ -99,9 +99,10 @@ def test_finalise_files(monkeypatch, tmp_path):
     monkeypatch.setattr('uav.slam_utils.generate_pose_comparison_plot', lambda: calls.append('pose_plot'))
     nl.STOP_FLAG_PATH = tmp_path/'stop.flag'
     nl.STOP_FLAG_PATH.write_text('1')
+    monkeypatch.setattr('uav.paths.STOP_FLAG_PATH', nl.STOP_FLAG_PATH, raising=False)
     log_dir = Path('flow_logs')
     log_dir.mkdir(exist_ok=True)
-    (log_dir / 'full_log_1234.csv').write_text('dummy')
+    (log_dir / 'full_log_1234.csv').write_text('x' * 200)
     ctx = types.SimpleNamespace(timestamp='1234')
     nl.finalise_files(ctx)
     assert any('analysis/visualise_flight.py' in ' '.join(c) for c in calls)
@@ -120,12 +121,13 @@ def test_finalise_files_calledprocesserror(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr('uav.slam_utils.generate_pose_comparison_plot', lambda: None)
 
     nl.STOP_FLAG_PATH = tmp_path / 'stop.flag'
+    monkeypatch.setattr('uav.paths.STOP_FLAG_PATH', nl.STOP_FLAG_PATH, raising=False)
     log_dir = Path('flow_logs')
     log_dir.mkdir(exist_ok=True)
-    (log_dir / 'full_log_ts.csv').write_text('dummy')
+    (log_dir / 'full_log_ts.csv').write_text('x' * 200)
     ctx = types.SimpleNamespace(timestamp='ts')
 
-    with caplog.at_level(nl.logging.ERROR):
+    with caplog.at_level(nl.logging.WARNING):
         nl.finalise_files(ctx)
 
     assert any('fail' in record.message for record in caplog.records)

--- a/tests/test_output_dir.py
+++ b/tests/test_output_dir.py
@@ -1,0 +1,36 @@
+import importlib
+import sys
+import types
+
+import tests.conftest  # ensure stubs loaded
+
+
+def test_output_dir_creates_logs(monkeypatch, tmp_path):
+    airsim_stub = types.SimpleNamespace(ImageRequest=object, ImageType=object)
+    monkeypatch.setitem(sys.modules, "airsim", airsim_stub)
+    nl = importlib.import_module("uav.nav_loop")
+    importlib.reload(nl)
+
+    monkeypatch.setattr(nl, "start_video_writer_thread", lambda *a, **k: types.SimpleNamespace(join=lambda: None))
+    monkeypatch.setattr(nl, "retain_recent_logs", lambda *a, **k: None)
+    monkeypatch.setattr(nl, "retain_recent_files", lambda *a, **k: None)
+    monkeypatch.setattr(nl, "retain_recent_views", lambda *a, **k: None)
+    monkeypatch.setattr(nl, "init_client", lambda *a, **k: None)
+    monkeypatch.setattr(nl, "OpticalFlowTracker", lambda *a, **k: object())
+    monkeypatch.setattr(nl, "FlowHistory", lambda *a, **k: object())
+    monkeypatch.setattr(nl, "Navigator", lambda *a, **k: object())
+    monkeypatch.setattr(nl.cv2, "VideoWriter_fourcc", lambda *a: 0)
+    monkeypatch.setattr(nl.cv2, "VideoWriter", lambda *a, **k: types.SimpleNamespace(release=lambda: None))
+
+    out_dir = tmp_path / "out"
+    args = types.SimpleNamespace(goal_x=0.0, goal_y=0.0, max_duration=1, output_dir=str(out_dir))
+    dummy_future = types.SimpleNamespace(join=lambda *a, **k: None)
+    client = types.SimpleNamespace(
+        listVehicles=lambda: [],
+        takeoffAsync=lambda: dummy_future,
+        moveToPositionAsync=lambda *a, **k: dummy_future,
+    )
+    ctx = nl.setup_environment(args, client)
+    ctx.log_file.close()
+    log_files = list((out_dir / "flow_logs").glob("full_log_*.csv"))
+    assert log_files and log_files[0].exists()

--- a/uav/cli.py
+++ b/uav/cli.py
@@ -42,4 +42,9 @@ def parse_args():
         help="Minimum inliers for SLAM stability",
     )
     parser.add_argument("--log-timestamp", type=str, help="Timestamp used to sync logging across modules")
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="Directory to store logs and analysis outputs",
+    )
     return parser.parse_args()

--- a/uav/context.py
+++ b/uav/context.py
@@ -47,3 +47,4 @@ class NavContext:
     perception_thread: Optional[Thread] = None
     grace_logged: bool = False
     startup_grace_over: bool = False
+    output_dir: str = "."

--- a/uav/logging_helpers.py
+++ b/uav/logging_helpers.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from datetime import datetime
+from pathlib import Path
 
 import cv2
 
@@ -179,7 +180,10 @@ def handle_reset(client, ctx, frame_count):
     log_file.close()
     ctx.timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
     timestamp = ctx.timestamp
-    log_path = f"flow_logs/full_log_{timestamp}.csv"
+    base_dir = Path(getattr(ctx, "output_dir", "."))
+    flow_dir = base_dir / "flow_logs"
+    flow_dir.mkdir(parents=True, exist_ok=True)
+    log_path = flow_dir / f"full_log_{timestamp}.csv"
     with open(log_path, 'w') as new_log:
         new_log.write(
             "frame,flow_left,flow_center,flow_right,"
@@ -193,10 +197,10 @@ def handle_reset(client, ctx, frame_count):
         )
     log_file = open(log_path, 'a')
     ctx.log_file = log_file
-    retain_recent_logs("flow_logs")
-    retain_recent_logs("logs")
-    retain_recent_files("analysis", "slam_traj_*.html", keep=5)
-    retain_recent_files("analysis", "slam_output_*.mp4", keep=5)
+    retain_recent_logs(str(flow_dir))
+    retain_recent_logs(str(base_dir / "logs"))
+    retain_recent_files(str(base_dir / "analysis"), "slam_traj_*.html", keep=5)
+    retain_recent_files(str(base_dir / "analysis"), "slam_output_*.mp4", keep=5)
 
     frame_queue.put(None)
     video_thread.join()

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -85,9 +85,11 @@ def setup_environment(args, client):
     start_time = time.time()
     GOAL_X, MAX_SIM_DURATION = args.goal_x, args.max_duration
     logger.info("Config:\n  Goal X: %sm\n  Max Duration: %ss", GOAL_X, MAX_SIM_DURATION)
+    output_base = Path(getattr(args, "output_dir", "."))
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    os.makedirs("flow_logs", exist_ok=True)
-    log_file = open(f"flow_logs/full_log_{timestamp}.csv", 'w')
+    flow_dir = output_base / "flow_logs"
+    flow_dir.mkdir(parents=True, exist_ok=True)
+    log_file = open(flow_dir / f"full_log_{timestamp}.csv", 'w')
     log_file.write(
         "frame,flow_left,flow_center,flow_right,"
         "delta_left,delta_center,delta_right,flow_std,"
@@ -98,10 +100,10 @@ def setup_environment(args, client):
         "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss,"
         "sudden_rise,center_blocked,combination_flow,minimum_flow\n"
     )
-    retain_recent_logs("flow_logs")
-    retain_recent_logs("logs")
-    retain_recent_files("analysis", "slam_traj_*.html", keep=5)
-    retain_recent_files("analysis", "slam_output_*.mp4", keep=5)
+    retain_recent_logs(str(flow_dir))
+    retain_recent_logs(str(output_base / "logs"))
+    retain_recent_files(str(output_base / "analysis"), "slam_traj_*.html", keep=5)
+    retain_recent_files(str(output_base / "analysis"), "slam_output_*.mp4", keep=5)
     try: fourcc = cv2.VideoWriter_fourcc(*'MJPG')
     except AttributeError: fourcc = cv2.FOURCC(*'MJPG')
     out = cv2.VideoWriter(config.VIDEO_OUTPUT, fourcc, config.VIDEO_FPS, config.VIDEO_SIZE)
@@ -124,6 +126,7 @@ def setup_environment(args, client):
         start_time=start_time,
         fps_list=[],
         fourcc=fourcc,
+        output_dir=str(output_base),
     )
     return ctx
 
@@ -723,7 +726,8 @@ def finalise_files(ctx):
     logger.info(f"🎯 Starting post-flight analysis for timestamp: {timestamp}")
     
     try:
-        log_csv = f"flow_logs/full_log_{timestamp}.csv"
+        base_dir = Path(getattr(ctx, "output_dir", "."))
+        log_csv = base_dir / "flow_logs" / f"full_log_{timestamp}.csv"
         
         # Check if log file exists and has data
         if not os.path.exists(log_csv):
@@ -739,11 +743,12 @@ def finalise_files(ctx):
         logger.info(f"Processing log file: {log_csv} ({file_size} bytes)")
         
         # Ensure analysis directory exists
-        os.makedirs("analysis", exist_ok=True)
+        analysis_dir = base_dir / "analysis"
+        analysis_dir.mkdir(parents=True, exist_ok=True)
         
         # Generate flight visualization via subprocess for testability
         try:
-            html_output = f"analysis/flight_view_{timestamp}.html"
+            html_output = str(analysis_dir / f"flight_view_{timestamp}.html")
             logger.info(f"Generating flight visualization: {html_output}")
 
             visualization_script = os.path.abspath("analysis/visualise_flight.py")
@@ -753,7 +758,7 @@ def finalise_files(ctx):
                     visualization_script,
                     html_output,
                     "--log",
-                    log_csv,
+                    str(log_csv),
                 ],
                 check=True,
             )
@@ -766,7 +771,7 @@ def finalise_files(ctx):
 
         # Generate performance plots via subprocess
         try:
-            perf_output = f"analysis/performance_{timestamp}.html"
+            perf_output = str(analysis_dir / f"performance_{timestamp}.html")
             logger.info(f"Generating performance plots: {perf_output}")
 
             perf_script = os.path.abspath("analysis/performance_plots.py")
@@ -774,7 +779,7 @@ def finalise_files(ctx):
                 [
                     sys.executable,
                     perf_script,
-                    log_csv,
+                    str(log_csv),
                     "--output",
                     perf_output,
                 ],
@@ -789,7 +794,7 @@ def finalise_files(ctx):
 
         # Generate flight report (if analyse module exists)
         try:
-            report_path = f"analysis/flight_report_{timestamp}.html"
+            report_path = str(analysis_dir / f"flight_report_{timestamp}.html")
             analyse_script = os.path.abspath("analysis/analyse.py")
             
             if os.path.exists(analyse_script):
@@ -799,7 +804,7 @@ def finalise_files(ctx):
                     [
                         sys.executable,
                         analyse_script,
-                        log_csv,
+                        str(log_csv),
                         "-o",
                         report_path,
                     ],
@@ -829,9 +834,9 @@ def finalise_files(ctx):
         # Summary of generated files
         generated_files = []
         for file_pattern in [
-            f"analysis/flight_view_{timestamp}.html",
-            f"analysis/performance_{timestamp}.html", 
-            f"analysis/flight_report_{timestamp}.html"
+            analysis_dir / f"flight_view_{timestamp}.html",
+            analysis_dir / f"performance_{timestamp}.html",
+            analysis_dir / f"flight_report_{timestamp}.html"
         ]:
             if os.path.exists(file_pattern):
                 generated_files.append(file_pattern)
@@ -852,7 +857,7 @@ def finalise_files(ctx):
     # Clean up files
     try:
         from uav.utils import retain_recent_views
-        retain_recent_views("analysis", 5)
+        retain_recent_views(str(analysis_dir), 5)
         logger.info("✅ Old analysis files cleaned up")
     except Exception as cleanup_error:
         logger.error(f"Error retaining recent views: {cleanup_error}")


### PR DESCRIPTION
## Summary
- support `--output-dir` CLI argument
- pass output directory through the navigation setup
- write logs and analysis into the specified folder
- document the new flag in README
- test that logs respect the given output directory

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68810a80801083258bff35688ed61aa7