### PR TITLE
Ensure GUI exits after simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ Pressing the stop button touches `stop.flag` so the running process can safely
 land and exit. The launcher now waits up to `GRACE_TIME` seconds for
 `main.py` to terminate after creating this flag before forcefully killing any
 remaining processes.
+The GUI also monitors for the stop event and closes automatically when the
+simulation ends, such as after reaching the goal or hitting the maximum
+duration.
 
 ### SLAM Utilities
 

--- a/analysis/performance_plots.py
+++ b/analysis/performance_plots.py
@@ -6,11 +6,12 @@ import argparse
 from pathlib import Path
 
 import pandas as pd
-from plotly.subplots import make_subplots
-import plotly.graph_objects as go
+from typing import Any
+
+# Plotly is imported lazily inside build_plot so tests can provide stubs
 
 
-def build_plot(df: pd.DataFrame) -> go.Figure:
+def build_plot(df: pd.DataFrame) -> Any:
     """Return a Plotly figure showing CPU and memory usage.
 
     Parameters
@@ -25,6 +26,10 @@ def build_plot(df: pd.DataFrame) -> go.Figure:
     else:
         x = df.index
         x_title = "Frame"
+
+    # Import plotly only when needed so tests can stub these modules
+    from plotly.subplots import make_subplots
+    import plotly.graph_objects as go
 
     cpu = df.get("cpu_percent", pd.Series(dtype=float))
     mem = df.get("memory_rss", pd.Series(dtype=float)) / (1024 * 1024)

--- a/launch_all.py
+++ b/launch_all.py
@@ -143,6 +143,9 @@ class Launcher:
         """Terminate all started subprocesses and clean temporary files."""
         self.logger.info("[SHUTDOWN] Initiating shutdown sequence for all subprocesses.")
 
+        # Ensure any running GUI exits when the simulation finishes
+        exit_flag.set()
+
         if exit_flag.is_set() or STOP_FLAG.exists():
             self.logger.info("[SHUTDOWN] Shutdown signal detected. Proceeding with shutdown.")
         else:

--- a/uav/interface.py
+++ b/uav/interface.py
@@ -195,9 +195,19 @@ def launch_control_gui(param_refs, nav_mode="unknown"):
     tk.Label(root, text="System Usage:").pack(pady=(10, 0))
     tk.Label(root, textvariable=perf_val).pack()
 
+    def check_exit():
+        if exit_flag.is_set():
+            try:
+                root.destroy()
+            except Exception:
+                pass
+        else:
+            root.after(500, check_exit)
+
     update_labels()
     update_status_lights()
     update_perf()
+    check_exit()
     root.mainloop()
 
 def start_gui(param_refs=None, nav_mode="unknown"):
@@ -229,4 +239,14 @@ def gui_exit():
         command=exit_flag.set,
     )
     btn.pack(expand=True)
+    def check_exit():
+        if exit_flag.is_set():
+            try:
+                root.destroy()
+            except Exception:
+                pass
+        else:
+            root.after(500, check_exit)
+
+    check_exit()
     root.mainloop()

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -742,8 +742,10 @@ def finalise_files(ctx):
         # Check log file size
         file_size = os.path.getsize(log_csv)
         if file_size < 100:  # Less than 100 bytes probably means empty/corrupt
-            logger.warning(f"Log file appears empty or corrupt: {log_csv} ({file_size} bytes)")
-            return
+            logger.warning(
+                f"Log file appears empty or corrupt: {log_csv} ({file_size} bytes)"
+            )
+        logger.info(f"Processing log file: {log_csv} ({file_size} bytes)")
         
         logger.info(f"Processing log file: {log_csv} ({file_size} bytes)")
         
@@ -868,7 +870,6 @@ def finalise_files(ctx):
 
     # Remove stop flag
     try:
-        from uav.paths import STOP_FLAG_PATH
         if os.path.exists(STOP_FLAG_PATH):
             os.remove(STOP_FLAG_PATH)
             logger.info("✅ Stop flag file removed")


### PR DESCRIPTION
## Summary
- shut down GUI when the launcher stops all subprocesses
- allow interface windows to close when exit_flag is set
- keep analysing logs even if they are small
- defer Plotly imports so tests can stub them
- document automatic GUI exit

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: test suite reports 19 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68810b960d748325997c6afbc8dafe29