### PR TITLE
Remove unused settling attribute

### DIFF
--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -154,7 +154,7 @@ def test_dodge_settle_duration_short():
     nav = Navigator(client)
     before = time.time()
     nav.dodge(0, 0, 20)
-    assert nav.settling is False
+    assert not hasattr(nav, "settling")
 
 
 def test_resume_forward_not_called_during_grace():

--- a/uav/navigation.py
+++ b/uav/navigation.py
@@ -24,11 +24,9 @@ class Navigator:
         self.client = client
         self.braked = False
         self.dodging = False
-        self.settling = False  # Maintain attribute for compatibility
         self.last_movement_time = time.time()
         self.grace_used = False  # add in __init__
         self.grace_period_end_time: float = 0.0
-        # self.settle_end_time = 0  # Removed settling logic
         self.just_resumed = False
         self.resume_grace_end_time = 0
 


### PR DESCRIPTION
## Summary
- drop `Navigator.settling` and related comment
- update navigator tests to avoid relying on the removed attribute

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: various tests in visualisation and launch helpers fail)*

------
https://chatgpt.com/codex/tasks/task_e_68812c9014c8832585bf0d4c9e1e219b