### PR TITLE
Remove extra metrics from GUI

### DIFF
--- a/uav/interface.py
+++ b/uav/interface.py
@@ -23,7 +23,6 @@ from threading import Thread
 from threading import Event
 from .context import ParamRefs
 
-from .performance import get_cpu_percent, get_memory_info
 
 # Use a multiprocessing.Event to signal when the application should exit
 exit_flag = Event()
@@ -34,9 +33,9 @@ def launch_control_gui(param_refs, nav_mode="unknown"):
     Parameters
     ----------
     param_refs : ParamRefs
-        Dataclass containing mutable lists used by the navigation loop to expose
-        real-time values such as optical flow magnitudes and the current state.
-        These values are shown in the GUI and updated periodically.
+        Dataclass containing shared navigation parameters. The GUI no longer
+        displays the flow magnitudes or current state, but ``param_refs`` is
+        retained for compatibility.
     nav_mode : str, optional
         Name of the navigation mode to pre-select in the dropdown menu.
         """
@@ -57,12 +56,6 @@ def launch_control_gui(param_refs, nav_mode="unknown"):
         from pathlib import Path
         Path("flags/start_nav.flag").touch()
 
-    def update_labels():
-        l_val.set(f"{param_refs['L'][0]:.2f}")  # Flow magnitude label for left sensor
-        c_val.set(f"{param_refs['C'][0]:.2f}")  # Flow magnitude label for center sensor
-        r_val.set(f"{param_refs['R'][0]:.2f}")  # Flow magnitude label for right sensor
-        state_val.set(param_refs['state'][0])  # Current state of the UAV label
-        root.after(200, update_labels) # Update every 200ms
 
     def update_status_lights():
         all_ready = True 
@@ -80,21 +73,11 @@ def launch_control_gui(param_refs, nav_mode="unknown"):
             start_nav_btn.config(state="disabled")
         root.after(500, update_status_lights) # Update every 500ms
 
-    def update_perf():
-        cpu = get_cpu_percent()
-        mem_mb = get_memory_info().rss / (1024 * 1024)
-        perf_val.set(f"CPU: {cpu:.1f}%  MEM: {mem_mb:.1f} MB")
-        root.after(1000, update_perf)  # Update every second
 
     root = tk.Tk() # Create the main application window
     root.title("Hybrid Navigation Simulator") # Set the window title
     root.geometry("340x420") # Set the window size
 
-    l_val = tk.StringVar()  # Flow magnitude for left sensor
-    c_val = tk.StringVar()  # Flow magnitude for center sensor
-    r_val = tk.StringVar()  # Flow magnitude for right sensor
-    state_val = tk.StringVar()  # Current state of the UAV
-    perf_val = tk.StringVar()  # CPU & memory usage
 
     # Set the initial state value
     tk.Label(root, text=f"Navigation Mode: {nav_mode.upper()}", fg="blue", font=("Arial", 10, "bold")).pack(pady=(5, 0))
@@ -175,25 +158,6 @@ def launch_control_gui(param_refs, nav_mode="unknown"):
         fg='white',
     ).pack(pady=5)
 
-    # Flow magnitude labels
-    tk.Label(root, text="Flow Magnitudes").pack(pady=5)
-
-    # Create a frame to hold the flow magnitude labels in a grid layout
-    flow_frame = tk.Frame(root)
-    flow_frame.pack()
-    tk.Label(flow_frame, text="Left:").grid(row=0, column=0, sticky='e')
-    tk.Label(flow_frame, textvariable=l_val).grid(row=0, column=1, sticky='w')
-    tk.Label(flow_frame, text="Center:").grid(row=1, column=0, sticky='e')
-    tk.Label(flow_frame, textvariable=c_val).grid(row=1, column=1, sticky='w')
-    tk.Label(flow_frame, text="Right:").grid(row=2, column=0, sticky='e')
-    tk.Label(flow_frame, textvariable=r_val).grid(row=2, column=1, sticky='w')
-
-    # Current state label
-    tk.Label(root, text="Current State:").pack(pady=(10, 0))
-    tk.Label(root, textvariable=state_val).pack()
-
-    tk.Label(root, text="System Usage:").pack(pady=(10, 0))
-    tk.Label(root, textvariable=perf_val).pack()
 
     def check_exit():
         if exit_flag.is_set():
@@ -204,9 +168,7 @@ def launch_control_gui(param_refs, nav_mode="unknown"):
         else:
             root.after(500, check_exit)
 
-    update_labels()
     update_status_lights()
-    update_perf()
     check_exit()
     root.mainloop()
 


### PR DESCRIPTION
## Summary
- trim unused imports and docstring
- drop flow magnitude, system usage and state labels from the GUI

## Testing
- `pytest -q` *(fails: test_launch_all_main_flag_flow, test_detect_obstacle, test_brake_when_side_flow_high, test_blind_forward_with_low_flow, test_brake_updates_flags_and_calls, test_dodge_left_sets_flags_and_calls, test_ambiguous_dodge_forces_lower_flow_side, test_navigation_skips_actions_during_grace_after_blind_forward, test_slam_navigation_calls_navigator, test_slam_nav_uses_airsim_pose, test_slam_navigation_performs_bootstrap, test_slam_bootstrap_runs_when_tracking_lost, test_slam_loop_exits_at_goal, test_is_obstacle_ahead_detects_obstacle, test_is_obstacle_ahead_handles_missing_image, test_image_streamer_sends_headers_and_data, test_build_plot_returns_figure, test_obstacles_add_traces, test_colour_and_orientation)*

------
https://chatgpt.com/codex/tasks/task_e_6882459da3ec8325af59e2cec39024da