### PR TITLE
Introduce NavigationState enum and refactor navigation

### DIFF
--- a/tests/test_navigation_step.py
+++ b/tests/test_navigation_step.py
@@ -48,23 +48,24 @@ def _make_nav():
         grace_period_end_time=0.0,
         last_movement_time=0.0,
     )
-    nav.brake = mock.MagicMock(return_value="brake")
-    nav.blind_forward = mock.MagicMock(return_value="blind_forward")
-    nav.dodge = mock.MagicMock(return_value="dodge_left")
+    nav.brake = mock.MagicMock(return_value=NavigationState.BRAKE)
+    nav.blind_forward = mock.MagicMock(return_value=NavigationState.BLIND_FORWARD)
+    nav.dodge = mock.MagicMock(return_value=NavigationState.DODGE_LEFT)
     nav.maintain_dodge = mock.MagicMock()
-    nav.resume_forward = mock.MagicMock(return_value="resume")
-    nav.nudge_forward = mock.MagicMock(return_value="nudge")
-    nav.reinforce = mock.MagicMock(return_value="reinforce")
-    nav.timeout_recover = mock.MagicMock(return_value="timeout")
+    nav.resume_forward = mock.MagicMock(return_value=NavigationState.RESUME)
+    nav.nudge_forward = mock.MagicMock(return_value=NavigationState.NUDGE)
+    nav.reinforce = mock.MagicMock(return_value=NavigationState.RESUME_REINFORCE)
+    nav.timeout_recover = mock.MagicMock(return_value=NavigationState.TIMEOUT_NUDGE)
     return nav
 
 
 from uav.context import ParamRefs
+from uav.navigation_state import NavigationState
 
 
 def _default_params():
     return ParamRefs(
-        state=[None],
+        state=[NavigationState.NONE],
         prev_L=[0.0],
         prev_C=[0.0],
         prev_R=[0.0],
@@ -106,7 +107,7 @@ def test_brake_when_side_flow_high(monkeypatch):
         params,
     )
 
-    assert result[0] == "brake"
+    assert result[0] is NavigationState.BRAKE
     nav.brake.assert_called_once()
     nav.blind_forward.assert_not_called()
 
@@ -143,7 +144,7 @@ def test_blind_forward_with_low_flow(monkeypatch):
         params,
     )
 
-    assert result[0] == "blind_forward"
+    assert result[0] is NavigationState.BLIND_FORWARD
     nav.blind_forward.assert_called_once()
     nav.brake.assert_not_called()
 
@@ -190,6 +191,6 @@ def test_dodge_when_obstacle_and_sides_clear(monkeypatch):
         params,
     )
 
-    assert result[0].startswith("dodge")
+    assert result[0] in (NavigationState.DODGE_LEFT, NavigationState.DODGE_RIGHT)
     nav.dodge.assert_called_once()
     assert nav.dodge.call_args.kwargs.get("direction") == "left"

--- a/uav/__init__.py
+++ b/uav/__init__.py
@@ -2,6 +2,7 @@
 
 from .perception import OpticalFlowTracker, FlowHistory
 from .navigation import Navigator
+from .navigation_state import NavigationState
 from .context import ParamRefs, NavContext
 from .interface import exit_flag, start_gui
 from .utils import apply_clahe, get_yaw, get_speed, get_drone_state
@@ -14,6 +15,7 @@ __all__ = [
     "ParamRefs",
     "NavContext",
     "Navigator",
+    "NavigationState",
     "exit_flag",
     "start_gui",
     "apply_clahe",

--- a/uav/context.py
+++ b/uav/context.py
@@ -19,7 +19,7 @@ class ParamRefs:
     delta_L: List[float] = field(default_factory=lambda: [0.0])
     delta_C: List[float] = field(default_factory=lambda: [0.0])
     delta_R: List[float] = field(default_factory=lambda: [0.0])
-    state: List[str] = field(default_factory=lambda: [''])
+    state: List[Any] = field(default_factory=lambda: [''])
     reset_flag: List[bool] = field(default_factory=lambda: [False])
 
 
@@ -32,7 +32,7 @@ class NavContext:
     tracker: Any
     flow_history: Any
     navigator: Any
-    state_history: Deque[str]
+    state_history: Deque[Any]
     pos_history: Deque[Any]
     frame_queue: Queue
     video_thread: Thread

--- a/uav/logging_helpers.py
+++ b/uav/logging_helpers.py
@@ -107,6 +107,7 @@ def write_frame_output(
     cpu_percent = get_cpu_percent()
     mem_rss = get_memory_info().rss
     fps_list.append(actual_fps)
+    state_str_name = state_str.name if hasattr(state_str, "name") else str(state_str)
     log_line = format_log_line(
         frame_count,
         smooth_L,
@@ -122,7 +123,7 @@ def write_frame_output(
         brake_thres,
         dodge_thres,
         actual_fps,
-        state_str,
+        state_str_name,
         collided,
         obstacle_detected,
         side_safe,

--- a/uav/navigation_state.py
+++ b/uav/navigation_state.py
@@ -1,0 +1,14 @@
+from enum import Enum, auto
+
+class NavigationState(Enum):
+    """Enumerates high level navigation actions."""
+
+    NONE = auto()
+    BRAKE = auto()
+    DODGE_LEFT = auto()
+    DODGE_RIGHT = auto()
+    RESUME = auto()
+    BLIND_FORWARD = auto()
+    NUDGE = auto()
+    RESUME_REINFORCE = auto()
+    TIMEOUT_NUDGE = auto()

--- a/uav/overlay.py
+++ b/uav/overlay.py
@@ -72,7 +72,8 @@ def draw_overlay(
     # Status overlay text (draw after blending)
     cv2.putText(img, f"Frame: {frame_count}", (10, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
     cv2.putText(img, f"Speed: {speed:.2f}", (10, 55), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
-    cv2.putText(img, f"State: {state}", (10, 85), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
+    state_str = state.name if hasattr(state, "name") else str(state)
+    cv2.putText(img, f"State: {state_str}", (10, 85), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
     cv2.putText(img, f"Sim Time: {sim_time:.2f}s", (10, 115), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
 
     if in_grace:


### PR DESCRIPTION
## Summary
- add `NavigationState` enum for navigation actions
- update Navigator and navigation core to use the enum
- adapt overlay and logging to handle enums
- update context types and tests for new enum

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688264322768832593851dd78d22d7dc