### PR TITLE
Refactor perception stats into dataclass

### DIFF
--- a/tests/test_frame_stats.py
+++ b/tests/test_frame_stats.py
@@ -1,0 +1,38 @@
+import numpy as np
+from uav.perception import PerceptionData, FrameStats
+
+
+def test_frame_stats_attributes():
+    data = PerceptionData(
+        vis_img=np.zeros((1, 1, 3), dtype=np.uint8),
+        good_old=np.zeros((0, 2)),
+        flow_vectors=np.zeros((0, 2)),
+        flow_std=0.0,
+        simgetimage_s=0.0,
+        decode_s=0.0,
+        processing_s=0.0,
+    )
+    stats = FrameStats(
+        smooth_L=1.0,
+        smooth_C=2.0,
+        smooth_R=3.0,
+        delta_L=0.1,
+        delta_C=0.2,
+        delta_R=0.3,
+        probe_mag=0.4,
+        probe_count=5,
+        left_count=1,
+        center_count=2,
+        right_count=3,
+        top_mag=0.5,
+        mid_mag=0.6,
+        bottom_mag=0.7,
+        top_count=4,
+        mid_count=5,
+        bottom_count=6,
+        in_grace=True,
+    )
+    assert stats.smooth_L == 1.0
+    assert stats.probe_count == 5
+    assert isinstance(data, PerceptionData)
+

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -25,7 +25,7 @@ from uav.overlay import draw_overlay
 from uav.navigation_rules import compute_thresholds
 from uav.video_utils import start_video_writer_thread
 from uav.logging_utils import format_log_line
-from uav.perception import OpticalFlowTracker, FlowHistory
+from uav.perception import OpticalFlowTracker, FlowHistory, FrameStats, PerceptionData
 from uav.navigation import Navigator
 from uav.state_checks import in_grace_period
 from uav.scoring import compute_region_stats
@@ -237,33 +237,32 @@ def update_navigation_state(client, args, ctx, data, frame_count, time_now, max_
     )
     if processed is None:
         return None
-    (
-        vis_img,
-        good_old,
-        flow_vectors,
-        flow_std,
-        simgetimage_s,
-        decode_s,
-        processing_s,
-        smooth_L,
-        smooth_C,
-        smooth_R,
-        delta_L,
-        delta_C,
-        delta_R,
-        probe_mag,
-        probe_count,
-        left_count,
-        center_count,
-        right_count,
-        top_mag,
-        mid_mag,
-        bottom_mag,
-        top_count,
-        mid_count,
-        bottom_count,
-        in_grace,
-    ) = processed
+    perception_data, stats = processed
+    vis_img = perception_data.vis_img
+    good_old = perception_data.good_old
+    flow_vectors = perception_data.flow_vectors
+    flow_std = perception_data.flow_std
+    simgetimage_s = perception_data.simgetimage_s
+    decode_s = perception_data.decode_s
+    processing_s = perception_data.processing_s
+    smooth_L = stats.smooth_L
+    smooth_C = stats.smooth_C
+    smooth_R = stats.smooth_R
+    delta_L = stats.delta_L
+    delta_C = stats.delta_C
+    delta_R = stats.delta_R
+    probe_mag = stats.probe_mag
+    probe_count = stats.probe_count
+    left_count = stats.left_count
+    center_count = stats.center_count
+    right_count = stats.right_count
+    top_mag = stats.top_mag
+    mid_mag = stats.mid_mag
+    bottom_mag = stats.bottom_mag
+    top_count = stats.top_count
+    mid_count = stats.mid_count
+    bottom_count = stats.bottom_count
+    in_grace = stats.in_grace
     nav_decision = navigation_step(
         client,
         ctx.navigator,
@@ -306,33 +305,32 @@ def log_and_record_frame(
     time_now,
 ):
     """Overlay telemetry, log, and queue video frames."""
-    (
-        vis_img,
-        good_old,
-        flow_vectors,
-        flow_std,
-        simgetimage_s,
-        decode_s,
-        processing_s,
-        smooth_L,
-        smooth_C,
-        smooth_R,
-        delta_L,
-        delta_C,
-        delta_R,
-        probe_mag,
-        probe_count,
-        left_count,
-        center_count,
-        right_count,
-        top_mag,
-        mid_mag,
-        bottom_mag,
-        top_count,
-        mid_count,
-        bottom_count,
-        in_grace,
-    ) = processed
+    perception_data, stats = processed
+    vis_img = perception_data.vis_img
+    good_old = perception_data.good_old
+    flow_vectors = perception_data.flow_vectors
+    flow_std = perception_data.flow_std
+    simgetimage_s = perception_data.simgetimage_s
+    decode_s = perception_data.decode_s
+    processing_s = perception_data.processing_s
+    smooth_L = stats.smooth_L
+    smooth_C = stats.smooth_C
+    smooth_R = stats.smooth_R
+    delta_L = stats.delta_L
+    delta_C = stats.delta_C
+    delta_R = stats.delta_R
+    probe_mag = stats.probe_mag
+    probe_count = stats.probe_count
+    left_count = stats.left_count
+    center_count = stats.center_count
+    right_count = stats.right_count
+    top_mag = stats.top_mag
+    mid_mag = stats.mid_mag
+    bottom_mag = stats.bottom_mag
+    top_count = stats.top_count
+    mid_count = stats.mid_count
+    bottom_count = stats.bottom_count
+    in_grace = stats.in_grace
     (
         state_str,
         obstacle_detected,

--- a/uav/perception.py
+++ b/uav/perception.py
@@ -30,6 +30,30 @@ class PerceptionData:
     decode_s: float
     processing_s: float
 
+
+@dataclass
+class FrameStats:
+    """Per-frame metrics computed from optical flow."""
+
+    smooth_L: float
+    smooth_C: float
+    smooth_R: float
+    delta_L: float
+    delta_C: float
+    delta_R: float
+    probe_mag: float
+    probe_count: int
+    left_count: int
+    center_count: int
+    right_count: int
+    top_mag: float
+    mid_mag: float
+    bottom_mag: float
+    top_count: int
+    mid_count: int
+    bottom_count: int
+    in_grace: bool
+
 class FlowHistory:
     """Maintain a rolling window of recent flow magnitudes."""
 

--- a/uav/perception_loop.py
+++ b/uav/perception_loop.py
@@ -12,7 +12,7 @@ from airsim import ImageRequest, ImageType
 
 from uav import config
 from uav.scoring import compute_region_stats
-from uav.perception import filter_flow_by_depth, PerceptionData
+from uav.perception import filter_flow_by_depth, PerceptionData, FrameStats
 
 logger = logging.getLogger("perception")
 
@@ -183,12 +183,8 @@ def process_perception_data(
 
     Returns
     -------
-    tuple
-        ``(vis_img, good_old, flow_vectors, flow_std, simgetimage_s,
-        decode_s, processing_s, smooth_L, smooth_C, smooth_R, delta_L,
-        delta_C, delta_R, probe_mag, probe_count, left_count, center_count,
-        right_count, top_mag, mid_mag, bottom_mag, top_count, mid_count,
-        bottom_count, in_grace)``.
+    Tuple[PerceptionData, FrameStats]
+        The original :class:`PerceptionData` and computed frame statistics.
     """
     vis_img = data.vis_img
     good_old = data.good_old
@@ -272,30 +268,24 @@ def process_perception_data(
                f"Features: L:{left_count} C:{center_count} R:{right_count} | "
                f"Total filtered features: {len(good_old)}")
 
-    return (
-        vis_img,
-        good_old,
-        flow_vectors,
-        flow_std,
-        simgetimage_s,
-        decode_s,
-        processing_s,
-        smooth_L,
-        smooth_C,
-        smooth_R,
-        delta_L,
-        delta_C,
-        delta_R,
-        probe_mag,
-        probe_count,
-        left_count,
-        center_count,
-        right_count,
-        top_mag,
-        mid_mag,
-        bottom_mag,
-        top_count,
-        mid_count,
-        bottom_count,
-        in_grace,
+    stats = FrameStats(
+        smooth_L=smooth_L,
+        smooth_C=smooth_C,
+        smooth_R=smooth_R,
+        delta_L=delta_L,
+        delta_C=delta_C,
+        delta_R=delta_R,
+        probe_mag=probe_mag,
+        probe_count=probe_count,
+        left_count=left_count,
+        center_count=center_count,
+        right_count=right_count,
+        top_mag=top_mag,
+        mid_mag=mid_mag,
+        bottom_mag=bottom_mag,
+        top_count=top_count,
+        mid_count=mid_count,
+        bottom_count=bottom_count,
+        in_grace=in_grace,
     )
+    return data, stats


### PR DESCRIPTION
## Summary
- introduce `FrameStats` dataclass to hold per-frame metrics
- return `(PerceptionData, FrameStats)` from `process_perception_data`
- update navigation helpers to use the dataclass
- add minimal tests for `FrameStats`

## Testing
- `pytest tests/test_flow_history.py tests/test_utils.py tests/test_frame_stats.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a07125588325906e3160c2907787