### PR TITLE
Add SLAM metrics CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Two helper applications live under `linux_slam/app`:
 - `offline_slam_evaluation` now accepts `--data-dir=DIR` to specify where RGB and depth images are loaded from.
 - `tcp_slam_server` reads log and flag locations from the command line or the environment variables `SLAM_LOG_DIR`, `SLAM_FLAG_DIR` and `SLAM_IMAGE_DIR`.
 - `tcp_slam_server` can record the incoming stereo feed. Provide `--video-file=PATH` or set `SLAM_VIDEO_FILE` to override the default `logs/slam_feed.avi`.
+- `tcp_slam_server` writes per-frame metrics to `slam_metrics.csv` in the log directory.
 - `launch_slam_backend` automatically exports these variables, pointing to the
   repository's `flags/` and `logs/` folders, before starting `tcp_slam_server`.
 


### PR DESCRIPTION
## Summary
- create a slam_metrics.csv file when the SLAM server starts
- log timestamp, tracking state, inliers and covariance after each frame
- close the metrics file during server shutdown
- document the new CSV file

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: FileNotFoundError and hang)*

------
https://chatgpt.com/codex/tasks/task_e_6883131ff94083259c44c57a77308a4f