### PR TITLE
Add SLAM map point export

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Two helper applications live under `linux_slam/app`:
 - `offline_slam_evaluation` now accepts `--data-dir=DIR` to specify where RGB and depth images are loaded from.
 - `tcp_slam_server` reads log and flag locations from the command line or the environment variables `SLAM_LOG_DIR`, `SLAM_FLAG_DIR` and `SLAM_IMAGE_DIR`.
 - `tcp_slam_server` can record the incoming stereo feed. Provide `--video-file=PATH` or set `SLAM_VIDEO_FILE` to override the default `logs/slam_feed.avi`.
+- `tcp_slam_server` now also writes `MapPoints.txt` containing the final SLAM map points.
 - `launch_slam_backend` automatically exports these variables, pointing to the
   repository's `flags/` and `logs/` folders, before starting `tcp_slam_server`.
 

--- a/linux_slam/app/tcp_slam_server.cpp
+++ b/linux_slam/app/tcp_slam_server.cpp
@@ -769,6 +769,7 @@ int main(int argc, char **argv) {
 
     SLAM.SaveTrajectoryTUM(join_path(log_dir, "CameraTrajectory.txt"));
     SLAM.SaveKeyFrameTrajectoryTUM(join_path(log_dir, "KeyFrameTrajectory.txt"));
+    SLAM.SaveMapPoints(join_path(log_dir, "MapPoints.txt"));
 
     return 0;
 }

--- a/linux_slam/include/System.h
+++ b/linux_slam/include/System.h
@@ -112,8 +112,10 @@ public:
     // See format details at: http://www.cvlibs.net/datasets/kitti/eval_odometry.php
     void SaveTrajectoryKITTI(const string &filename);
 
-    // TODO: Save/Load functions
-    // SaveMap(const string &filename);
+    // Save/Load functions
+    // Save the current map points to a text file with one XYZ point per line.
+    // This is useful for debugging or offline analysis of the generated map.
+    void SaveMapPoints(const string &filename);
     // LoadMap(const string &filename);
 
     // Information from most recent processed frame

--- a/linux_slam/src/System.cc
+++ b/linux_slam/src/System.cc
@@ -26,6 +26,7 @@
 #include <pangolin/pangolin.h>
 #include <iomanip>
 #include <unistd.h>
+#include <fstream>
 
 
 namespace ORB_SLAM2
@@ -471,6 +472,28 @@ void System::SaveTrajectoryKITTI(const string &filename)
     }
     f.close();
     cout << endl << "trajectory saved!" << endl;
+}
+
+void System::SaveMapPoints(const string &filename)
+{
+    cout << endl << "Saving map points to " << filename << " ..." << endl;
+    vector<MapPoint*> vpMP = mpMap->GetAllMapPoints();
+
+    ofstream f;
+    f.open(filename.c_str());
+    f << fixed;
+
+    for(MapPoint* pMP : vpMP)
+    {
+        if(!pMP || pMP->isBad())
+            continue;
+        cv::Mat pos = pMP->GetWorldPos();
+        f << setprecision(6) << pos.at<float>(0) << " "
+          << pos.at<float>(1) << " "
+          << pos.at<float>(2) << endl;
+    }
+    f.close();
+    cout << endl << "map points saved!" << endl;
 }
 
 int System::GetTrackingState()


### PR DESCRIPTION
## Summary
- expose `SaveMapPoints` method in ORB-SLAM System
- record map points when shutting down `tcp_slam_server`
- document new map output in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883136e534483258cfeeac0e0181499