### PR TITLE
Add SLAM metrics CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Two helper applications live under `linux_slam/app`:
 - `offline_slam_evaluation` now accepts `--data-dir=DIR` to specify where RGB and depth images are loaded from.
 - `tcp_slam_server` reads log and flag locations from the command line or the environment variables `SLAM_LOG_DIR`, `SLAM_FLAG_DIR` and `SLAM_IMAGE_DIR`.
 - `tcp_slam_server` can record the incoming stereo feed. Provide `--video-file=PATH` or set `SLAM_VIDEO_FILE` to override the default `logs/slam_feed.avi`.
+- `tcp_slam_server` writes per-frame metrics to `slam_metrics.csv` in the log directory (frame number, relative timestamp, tracking state, inliers, covariance, and camera position).
 - `launch_slam_backend` automatically exports these variables, pointing to the
   repository's `flags/` and `logs/` folders, before starting `tcp_slam_server`.
 

--- a/linux_slam/app/tcp_slam_server.cpp
+++ b/linux_slam/app/tcp_slam_server.cpp
@@ -116,6 +116,14 @@ int main(int argc, char **argv) {
     create_directories(image_dir);
     create_directories(std::filesystem::path(video_file).parent_path().string());
 
+    // Create metrics CSV for runtime statistics
+    std::string metrics_file = join_path(log_dir, "slam_metrics.csv");
+    std::ofstream metrics_stream(metrics_file);
+    // Timestamp will be relative to when the server starts
+    double server_start_time = (double)cv::getTickCount() / cv::getTickFrequency();
+    if (metrics_stream.is_open())
+        metrics_stream << "frame,timestamp,tracking_state,inliers,covariance,x,y,z\n";
+
     std::string console_log = join_path(log_dir, "slam_console.txt");
     std::string console_err = join_path(log_dir, "slam_console_err.txt");
 
@@ -742,6 +750,24 @@ int main(int argc, char **argv) {
                             log_event("[DEBUG] Inlier count sent to Python receiver: " + std::to_string(inlier_count));
                         }
                         log_event("Pose (Twc) sent to Python receiver.");
+
+                        // Record metrics for this frame
+                        int tracking_state = -1;
+                        auto tracker_metrics = SLAM.GetTracker();
+                        if (tracker_metrics) tracking_state = tracker_metrics->mState;
+                        if (metrics_stream.is_open()) {
+                            double relative_time = timestamp - server_start_time;
+                            float x = 0.0f, y = 0.0f, z = 0.0f;
+                            if (!Twc_send.empty() && Twc_send.rows >= 3 && Twc_send.cols >= 4) {
+                                x = Twc_send.at<float>(0, 3);
+                                y = Twc_send.at<float>(1, 3);
+                                z = Twc_send.at<float>(2, 3);
+                            }
+                            metrics_stream << std::fixed << std::setprecision(6)
+                                           << frame_counter << ',' << relative_time << ','
+                                           << tracking_state << ',' << inlier_count << ','
+                                           << covariance_value << ',' << x << ',' << y << ',' << z << '\n';
+                        }
                     } else {
                         log_event("[WARN] send_pose() returned false.");
                     }
@@ -758,6 +784,7 @@ int main(int argc, char **argv) {
     log_event("[DEBUG] Closing sockets and cleaning up...");
     slam_server::cleanup_resources(sock, server_fd, pose_sock);
     if (pose_log_stream.is_open()) pose_log_stream.close();
+    if (metrics_stream.is_open()) metrics_stream.close();
     log_event("[DEBUG] Sockets closed. SLAM server shutting down.");
 
     if (slam_video_writer.isOpened()) {


### PR DESCRIPTION
## Summary
- create a `slam_metrics.csv` file when the SLAM server starts
- log frame number, relative timestamp, tracking state, inliers, covariance and camera position to the CSV after each frame
- close the metrics file during shutdown
- document the new metrics CSV

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libGL.so.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883131ff94083259c44c57a77308a4f