### PR TITLE
Include SLAM and GT coords in Python logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ setup_logging("run.log")  # also prints to stdout
 ```
 
 - Flight logs are stored in `flow_logs/` as `.csv` (use `--output-dir` to change the base folder)
+- Each log row contains the AirSim ground truth position (`pos_x`, `pos_y`, `pos_z`)
+  and the SLAM pose coordinates (`slam_x`, `slam_y`, `slam_z`).
 - 3D trajectory plots are saved in `analysis/` as interactive `.html` files
 - Runtime messages are configured via `uav.logging_config.setup_logging` using the standard `logging` module
 - SLAM pose and feature debugging is printed to stdout and stored in `logs/` (affected by `--output-dir`)

--- a/uav/logging_helpers.py
+++ b/uav/logging_helpers.py
@@ -81,6 +81,7 @@ def write_frame_output(
     center_blocked,
     combination_flow,
     minimum_flow,
+    slam_pos=None,
 ):
     """Overlay telemetry, write video, and log the frame."""
     pos, yaw, speed = get_drone_state(client)
@@ -141,6 +142,7 @@ def write_frame_output(
         obstacle_detected,
         side_safe,
         pos,
+        slam_pos,
         yaw,
         speed,
         time_now,
@@ -208,7 +210,7 @@ def handle_reset(client, ctx, frame_count):
             "left_count,center_count,right_count,"
             "brake_thres,dodge_thres,fps,"
             "state,collided,obstacle,side_safe,"
-            "pos_x,pos_y,pos_z,yaw,speed,"
+            "pos_x,pos_y,pos_z,slam_x,slam_y,slam_z,yaw,speed,"
             "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss,"
             "sudden_rise,center_blocked,combination_flow,minimum_flow\n"
         )

--- a/uav/logging_utils.py
+++ b/uav/logging_utils.py
@@ -21,6 +21,7 @@ def format_log_line(
     obstacle_detected,
     side_safe,
     pos,
+    slam_pos,
     yaw,
     speed,
     time_now,
@@ -38,13 +39,21 @@ def format_log_line(
 ) -> str:
     """Return a formatted CSV line for logging navigation state."""
 
+    slam_str = (
+        f"{slam_pos[0]:.2f},{slam_pos[1]:.2f},{slam_pos[2]:.2f},"
+        if slam_pos is not None
+        else ",,,"
+    )
+
     return (
         f"{frame_count},{smooth_L:.3f},{smooth_C:.3f},{smooth_R:.3f},"
         f"{delta_L:.3f},{delta_C:.3f},{delta_R:.3f},{flow_std:.3f},"
         f"{left_count},{center_count},{right_count},"
         f"{brake_thres:.2f},{dodge_thres:.2f},{actual_fps:.2f},"
         f"{state_str},{collided},{obstacle_detected},{int(side_safe)},"
-        f"{pos.x_val:.2f},{pos.y_val:.2f},{pos.z_val:.2f},{yaw:.2f},{speed:.2f},"
+        f"{pos.x_val:.2f},{pos.y_val:.2f},{pos.z_val:.2f},"
+        f"{slam_str}"
+        f"{yaw:.2f},{speed:.2f},"
         f"{time_now:.2f},{len(good_old)},"
         f"{simgetimage_s:.3f},{decode_s:.3f},{processing_s:.3f},{loop_elapsed:.3f},"
         f"{cpu_percent:.1f},{mem_rss},"

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -315,15 +315,21 @@ def log_slam_frame(ctx, frame_count, time_now, x, y, z, waypoint_index, dist_to_
     try:
         # Get drone state for additional context
         client = getattr(ctx, 'client', None)
+        gt_x = gt_y = gt_z = 0.0
         speed = 0.0
         yaw = 0.0
         if client:
             try:
                 pose = client.simGetVehiclePose("UAV")
-                speed = np.linalg.norm([pose.linear_velocity.x_val, 
-                                     pose.linear_velocity.y_val, 
-                                     pose.linear_velocity.z_val])
+                speed = np.linalg.norm([
+                    pose.linear_velocity.x_val,
+                    pose.linear_velocity.y_val,
+                    pose.linear_velocity.z_val,
+                ])
                 yaw = airsim.to_eularian_angles(pose.orientation)[2]
+                gt_x = pose.position.x_val
+                gt_y = pose.position.y_val
+                gt_z = pose.position.z_val
             except:
                 pass
         
@@ -344,7 +350,8 @@ def log_slam_frame(ctx, frame_count, time_now, x, y, z, waypoint_index, dist_to_
                    f"0,"                     # collided (assume no collision)
                    f"0,"                     # obstacle (N/A for SLAM)
                    f"1,"                     # side_safe (assume safe)
-                   f"{x:.6f},{y:.6f},{z:.6f}," # pos_x,pos_y,pos_z (actual SLAM position)
+                   f"{gt_x:.6f},{gt_y:.6f},{gt_z:.6f}," # GT coordinates
+                   f"{x:.6f},{y:.6f},{z:.6f}," # SLAM pose
                    f"{yaw:.6f},"             # yaw
                    f"{speed:.6f},"           # speed
                    f"{time_now:.6f},"        # time

--- a/uav/nav_runtime.py
+++ b/uav/nav_runtime.py
@@ -109,7 +109,7 @@ def setup_environment(args, client):
         "left_count,center_count,right_count,"
         "brake_thres,dodge_thres,fps,"
         "state,collided,obstacle,side_safe,"
-        "pos_x,pos_y,pos_z,yaw,speed,"
+        "pos_x,pos_y,pos_z,slam_x,slam_y,slam_z,yaw,speed,"
         "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss,"
         "sudden_rise,center_blocked,combination_flow,minimum_flow\n"
     )


### PR DESCRIPTION
## Summary
- extend full log headers to store SLAM pose coordinates alongside AirSim GT
- expose optional `slam_pos` in logging helpers
- record both GT and SLAM positions in `log_slam_frame`
- document new columns in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6883827c95b88325919a4c91bc32bf56