### PR TITLE
Add total frame to SLAM metrics log

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Two helper applications live under `linux_slam/app`:
 - `offline_slam_evaluation` now accepts `--data-dir=DIR` to specify where RGB and depth images are loaded from.
 - `tcp_slam_server` reads log and flag locations from the command line or the environment variables `SLAM_LOG_DIR`, `SLAM_FLAG_DIR` and `SLAM_IMAGE_DIR`.
 - `tcp_slam_server` can record the incoming stereo feed. Provide `--video-file=PATH` or set `SLAM_VIDEO_FILE` to override the default `logs/slam_feed.avi`.
-- `tcp_slam_server` writes per-frame metrics to `slam_metrics.csv` in the log directory (frame number, relative timestamp, tracking state, inliers, covariance, number of keyframes, map points, camera position and orientation as a quaternion).
+- `tcp_slam_server` writes per-frame metrics to `slam_metrics.csv` in the log directory (session frame number, total frame number, relative timestamp, tracking state, inliers, covariance, number of keyframes, map points, camera position and orientation as a quaternion).
 - `tcp_slam_server` also writes `MapPoints.txt` containing the final SLAM map points.
 - `launch_slam_backend` automatically exports these variables, pointing to the
   repository's `flags/` and `logs/` folders, before starting `tcp_slam_server`.

--- a/linux_slam/app/tcp_slam_server.cpp
+++ b/linux_slam/app/tcp_slam_server.cpp
@@ -142,7 +142,7 @@ int main(int argc, char **argv) {
     double server_start_time = (double)cv::getTickCount() / cv::getTickFrequency();
     if (metrics_stream.is_open()) {
         metrics_stream
-            << "frame,timestamp,tracking_state,inliers,covariance,keyframes,map_points,x,y,z,qx,qy,qz,qw\n";
+            << "frame,total_frame,timestamp,tracking_state,inliers,covariance,keyframes,map_points,x,y,z,qx,qy,qz,qw\n";
     }
     
     std::string console_log = join_path(log_dir, "slam_console.txt");
@@ -903,7 +903,7 @@ int main(int argc, char **argv) {
                             int keyframes = SLAM.KeyFramesInMap();
                             int map_points = SLAM.MapPointsInMap();
                             metrics_stream << std::fixed << std::setprecision(6)
-                                           << frame_counter << ',' << relative_time << ','
+                                           << frame_counter << ',' << total_frame_counter << ',' << relative_time << ','
                                            << tracking_state << ',' << inliers << ','
                                            << covariance_value << ',' << keyframes << ',' << map_points << ','
                                            << x << ',' << y << ',' << z << ','


### PR DESCRIPTION
## Summary
- add `total_frame` column header to SLAM metric CSV
- log `total_frame_counter` for each frame
- document the new CSV column in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: test_analyse_cli_produces_html, test_finalise_files, test_context_managers, test_logging_context)*

------
https://chatgpt.com/codex/tasks/task_e_68838805275c83258b3ef54ae89bd747