### PR TITLE
Rename reactive log

### DIFF
--- a/analysis/5_map_overlay.py
+++ b/analysis/5_map_overlay.py
@@ -260,8 +260,8 @@ def create_overlay_plot(trajectories: List[tuple], output_path: str):
         # Create trajectory name
         flight_name = f"Flight {i+1}"
         csv_name = Path(metadata["path"]).stem
-        if "full_log_" in csv_name:
-            timestamp = csv_name.replace("full_log_", "")
+        if "reactive_log_" in csv_name:
+            timestamp = csv_name.replace("reactive_log_", "")
             flight_name = f"Flight {timestamp[:8]}_{timestamp[9:13]}"
         
         # Add trajectory line

--- a/main.py
+++ b/main.py
@@ -196,7 +196,7 @@ def main() -> None:
             # plotter_thread.start()
             # atexit.register(save_interactive_plot)
 
-            ctx = setup_environment(args, client)
+            ctx = setup_environment(args, client, nav_mode="slam")
             set_state_ref(ctx.param_refs.state)
             start_perception_thread(ctx)
             slam_navigation_loop(args, client, ctx, config, pose_source=pose_source)
@@ -223,7 +223,7 @@ def main() -> None:
         wait_for_nav_trigger()
         init_client(client)
 
-        ctx = setup_environment(args, client)
+        ctx = setup_environment(args, client, nav_mode="reactive")
         start_perception_thread(ctx)
 
         # Logging: startup debug

--- a/tests/test_cleanup_helpers.py
+++ b/tests/test_cleanup_helpers.py
@@ -108,7 +108,7 @@ def test_finalise_files(monkeypatch, tmp_path):
     monkeypatch.setattr('uav.paths.STOP_FLAG_PATH', nl.STOP_FLAG_PATH, raising=False)
     log_dir = Path('flow_logs')
     log_dir.mkdir(exist_ok=True)
-    (log_dir / 'full_log_1234.csv').write_text('x' * 200)
+    (log_dir / 'reactive_log_1234.csv').write_text('x' * 200)
     ctx = types.SimpleNamespace(timestamp='1234')
     nl.finalise_files(ctx)
     assert any('analysis/visualise_flight.py' in ' '.join(c) for c in calls)
@@ -130,7 +130,7 @@ def test_finalise_files_calledprocesserror(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr('uav.paths.STOP_FLAG_PATH', nl.STOP_FLAG_PATH, raising=False)
     log_dir = Path('flow_logs')
     log_dir.mkdir(exist_ok=True)
-    (log_dir / 'full_log_ts.csv').write_text('x' * 200)
+    (log_dir / 'reactive_log_ts.csv').write_text('x' * 200)
     ctx = types.SimpleNamespace(timestamp='ts')
 
     with caplog.at_level(nl.logging.WARNING):

--- a/tests/test_log_columns.py
+++ b/tests/test_log_columns.py
@@ -14,7 +14,8 @@ def test_setup_environment_header_includes_perf(monkeypatch, tmp_path):
     monkeypatch.setattr(nl, "start_video_writer_thread", lambda *a, **k: types.SimpleNamespace(join=lambda: None))
     monkeypatch.setattr(nl, "retain_recent_logs", lambda *a, **k: None)
     monkeypatch.setattr(nl, "retain_recent_files", lambda *a, **k: None)
-    monkeypatch.setattr(nl, "retain_recent_views", lambda *a, **k: None)
+    if hasattr(nl, "retain_recent_views"):
+        monkeypatch.setattr(nl, "retain_recent_views", lambda *a, **k: None)
     monkeypatch.setattr(nl, "init_client", lambda *a, **k: None)
     monkeypatch.setattr(nl, "OpticalFlowTracker", lambda *a, **k: object())
     monkeypatch.setattr(nl, "FlowHistory", lambda *a, **k: object())
@@ -32,7 +33,7 @@ def test_setup_environment_header_includes_perf(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     ctx = nl.setup_environment(args, client)
     ctx.log_file.close()
-    log_file = next((tmp_path / "flow_logs").glob("full_log_*.csv"))
+    log_file = next((tmp_path / "flow_logs").glob("reactive_log_*.csv"))
     header = log_file.read_text().splitlines()[0]
     assert "cpu_percent" in header
     assert "memory_rss" in header

--- a/tests/test_output_dir.py
+++ b/tests/test_output_dir.py
@@ -14,7 +14,8 @@ def test_output_dir_creates_logs(monkeypatch, tmp_path):
     monkeypatch.setattr(nl, "start_video_writer_thread", lambda *a, **k: types.SimpleNamespace(join=lambda: None))
     monkeypatch.setattr(nl, "retain_recent_logs", lambda *a, **k: None)
     monkeypatch.setattr(nl, "retain_recent_files", lambda *a, **k: None)
-    monkeypatch.setattr(nl, "retain_recent_views", lambda *a, **k: None)
+    if hasattr(nl, "retain_recent_views"):
+        monkeypatch.setattr(nl, "retain_recent_views", lambda *a, **k: None)
     monkeypatch.setattr(nl, "init_client", lambda *a, **k: None)
     monkeypatch.setattr(nl, "OpticalFlowTracker", lambda *a, **k: object())
     monkeypatch.setattr(nl, "FlowHistory", lambda *a, **k: object())
@@ -32,5 +33,5 @@ def test_output_dir_creates_logs(monkeypatch, tmp_path):
     )
     ctx = nl.setup_environment(args, client)
     ctx.log_file.close()
-    log_files = list((out_dir / "flow_logs").glob("full_log_*.csv"))
+    log_files = list((out_dir / "flow_logs").glob("reactive_log_*.csv"))
     assert log_files and log_files[0].exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,13 +9,13 @@ def test_retain_recent_logs_keeps_latest(tmp_path):
 
     for i in range(6):
         ts = f"20240101_00000{i}"
-        p = log_dir / f"full_log_{ts}.csv"
+        p = log_dir / f"reactive_log_{ts}.csv"
         p.write_text("data")
 
     retain_recent_logs(str(log_dir), keep=3)
     remaining = sorted(f.name for f in log_dir.iterdir())
     assert remaining == [
-        f"full_log_20240101_00000{i}.csv" for i in range(3, 6)
+        f"reactive_log_20240101_00000{i}.csv" for i in range(3, 6)
     ]
 
 

--- a/uav/logging_helpers.py
+++ b/uav/logging_helpers.py
@@ -202,7 +202,7 @@ def handle_reset(client, ctx, frame_count):
     base_dir = Path(getattr(ctx, "output_dir", "."))
     flow_dir = base_dir / "flow_logs"
     flow_dir.mkdir(parents=True, exist_ok=True)
-    log_path = flow_dir / f"full_log_{timestamp}.csv"
+    log_path = flow_dir / f"reactive_log_{timestamp}.csv"
     with open(log_path, 'w') as new_log:
         new_log.write(
             "frame,flow_left,flow_center,flow_right,"

--- a/uav/nav_analysis.py
+++ b/uav/nav_analysis.py
@@ -31,7 +31,7 @@ def finalise_files(ctx):
 
     try:
         base_dir = Path(getattr(ctx, "output_dir", "."))
-        log_csv = base_dir / "flow_logs" / f"full_log_{timestamp}.csv"
+        log_csv = base_dir / "flow_logs" / f"reactive_log_{timestamp}.csv"
 
         if not os.path.exists(log_csv):
             logger.error(f"Log file not found: {log_csv}")

--- a/uav/nav_runtime.py
+++ b/uav/nav_runtime.py
@@ -63,7 +63,7 @@ __all__ = [
 
 # === Perception Processing ===
 
-def setup_environment(args, client):
+def setup_environment(args, client, nav_mode="reactive"):
     """Initialize the navigation environment and return a context dict."""
     from uav.interface import exit_flag
 
@@ -102,7 +102,9 @@ def setup_environment(args, client):
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     flow_dir = output_base / "flow_logs"
     flow_dir.mkdir(parents=True, exist_ok=True)
-    log_file = open(flow_dir / f"full_log_{timestamp}.csv", "w")
+    log_file = None
+    if nav_mode == "reactive":
+        log_file = open(flow_dir / f"reactive_log_{timestamp}.csv", "w")
     log_file.write(
         "frame,flow_left,flow_center,flow_right,"
         "delta_left,delta_center,delta_right,flow_std,"
@@ -113,8 +115,9 @@ def setup_environment(args, client):
         "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss,"
         "sudden_rise,center_blocked,combination_flow,minimum_flow\n"
     )
-    retain_recent_logs(str(flow_dir))
-    retain_recent_logs(str(output_base / "logs"))
+    if nav_mode == "reactive":
+        retain_recent_logs(str(flow_dir))
+        retain_recent_logs(str(output_base / "logs"))
     retain_recent_files(str(output_base / "analysis"), "slam_traj_*.html", keep=5)
     retain_recent_files(str(output_base / "analysis"), "slam_output_*.mp4", keep=5)
     try:

--- a/uav/utils.py
+++ b/uav/utils.py
@@ -55,12 +55,12 @@ def get_drone_state(client):
 
 
 def _timestamp_from_name(path: str) -> float:
-    """Return a UNIX timestamp parsed from ``full_log_YYYYMMDD_HHMMSS.csv``.
+    """Return a UNIX timestamp parsed from ``reactive_log_YYYYMMDD_HHMMSS.csv``.
 
     Falls back to the file's modification time if parsing fails.
     """
     name = os.path.basename(path)
-    ts = name[len("full_log_"):-len(".csv")]
+    ts = name[len("reactive_log_"):-len(".csv")]
     try:
         dt = datetime.strptime(ts, "%Y%m%d_%H%M%S")
         return dt.timestamp()
@@ -71,10 +71,10 @@ def _timestamp_from_name(path: str) -> float:
 def retain_recent_logs(log_dir: str, keep: int = 2) -> None:
     """
     Keep only the ``keep`` most recent logs for each log type in the logs folder.
-    Handles: full_log_*.csv, launch_*.log, slam_server_debug_*.log, pose_log_*.txt
+    Handles: reactive_log_*.csv, launch_*.log, slam_server_debug_*.log, pose_log_*.txt
     """
     log_patterns = [
-        "full_log_*.csv",
+        "reactive_log_*.csv",
         "launch_*.log",
         "slam_*.log",
         "pose_*.txt",


### PR DESCRIPTION
## Summary
- restrict log CSV to reactive navigation mode
- rename log file to `reactive_log_*`
- update utilities and tests for new name

## Testing
- `pytest -q tests/test_output_dir.py::test_output_dir_creates_logs`
- `pytest -q` *(fails: AssertionError in cleanup tests)*

------
https://chatgpt.com/codex/tasks/task_e_688398813b4083259f8e876e887889cc