### PR TITLE
Remove slam pose fields from log

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ setup_logging("run.log")  # also prints to stdout
 
 - Flight logs are stored in `flow_logs/` as `.csv` (use `--output-dir` to change the base folder)
 - Each log row contains the AirSim ground truth position (`pos_x`, `pos_y`, `pos_z`)
-  and the SLAM pose coordinates (`slam_x`, `slam_y`, `slam_z`).
+  along with orientation and performance metrics.
 - 3D trajectory plots are saved in `analysis/` as interactive `.html` files
 - Runtime messages are configured via `uav.logging_config.setup_logging` using the standard `logging` module
 - SLAM pose and feature debugging is printed to stdout and stored in `logs/` (affected by `--output-dir`)

--- a/uav/logging_helpers.py
+++ b/uav/logging_helpers.py
@@ -72,7 +72,6 @@ def write_frame_output(
     obstacle_detected,
     side_safe,
     brake_thres,
-    dodge_thres,
     simgetimage_s,
     decode_s,
     processing_s,
@@ -135,7 +134,6 @@ def write_frame_output(
         center_count,
         right_count,
         brake_thres,
-        dodge_thres,
         actual_fps,
         state_str_name,
         collided,
@@ -208,9 +206,9 @@ def handle_reset(client, ctx, frame_count):
             "frame,flow_left,flow_center,flow_right,"
             "delta_left,delta_center,delta_right,flow_std,"
             "left_count,center_count,right_count,"
-            "brake_thres,dodge_thres,fps,"
+            "brake_thres,fps,"
             "state,collided,obstacle,side_safe,"
-            "pos_x,pos_y,pos_z,slam_x,slam_y,slam_z,yaw,speed,"
+            "pos_x,pos_y,pos_z,yaw,speed,"
             "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss,"
             "sudden_rise,center_blocked,combination_flow,minimum_flow\n"
         )

--- a/uav/logging_utils.py
+++ b/uav/logging_utils.py
@@ -14,14 +14,12 @@ def format_log_line(
     center_count,
     right_count,
     brake_thres,
-    dodge_thres,
     actual_fps,
     state_str,
     collided,
     obstacle_detected,
     side_safe,
     pos,
-    slam_pos,
     yaw,
     speed,
     time_now,
@@ -39,20 +37,14 @@ def format_log_line(
 ) -> str:
     """Return a formatted CSV line for logging navigation state."""
 
-    slam_str = (
-        f"{slam_pos[0]:.2f},{slam_pos[1]:.2f},{slam_pos[2]:.2f},"
-        if slam_pos is not None
-        else ",,,"
-    )
 
     return (
         f"{frame_count},{smooth_L:.3f},{smooth_C:.3f},{smooth_R:.3f},"
         f"{delta_L:.3f},{delta_C:.3f},{delta_R:.3f},{flow_std:.3f},"
         f"{left_count},{center_count},{right_count},"
-        f"{brake_thres:.2f},{dodge_thres:.2f},{actual_fps:.2f},"
+        f"{brake_thres:.2f},{actual_fps:.2f},"
         f"{state_str},{collided},{obstacle_detected},{int(side_safe)},"
         f"{pos.x_val:.2f},{pos.y_val:.2f},{pos.z_val:.2f},"
-        f"{slam_str}"
         f"{yaw:.2f},{speed:.2f},"
         f"{time_now:.2f},{len(good_old)},"
         f"{simgetimage_s:.3f},{decode_s:.3f},{processing_s:.3f},{loop_elapsed:.3f},"

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -335,7 +335,7 @@ def log_slam_frame(ctx, frame_count, time_now, x, y, z, waypoint_index, dist_to_
         
         # Create log line compatible with existing analysis format
         # Format: frame,flow_left,flow_center,flow_right,delta_left,delta_center,delta_right,flow_std,
-        #         left_count,center_count,right_count,brake_thres,dodge_thres,fps,state,collided,obstacle,side_safe,
+        #         left_count,center_count,right_count,brake_thres,fps,state,collided,obstacle,side_safe,
         #         pos_x,pos_y,pos_z,yaw,speed,time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss,
         #         sudden_rise,center_blocked,combination_flow,minimum_flow
         
@@ -344,14 +344,13 @@ def log_slam_frame(ctx, frame_count, time_now, x, y, z, waypoint_index, dist_to_
                    f"0.0,0.0,0.0,"           # delta_left,delta_center,delta_right (N/A)
                    f"0.0,"                   # flow_std (N/A)
                    f"0,0,0,"                 # left_count,center_count,right_count (N/A)
-                   f"0.0,0.0,"               # brake_thres,dodge_thres (N/A)
+                   f"0.0,"                   # brake_thres (N/A)
                    f"10.0,"                  # fps (approximate SLAM rate)
                    f"{slam_state}_WP{waypoint_index + 1}," # state (includes waypoint info)
                    f"0,"                     # collided (assume no collision)
                    f"0,"                     # obstacle (N/A for SLAM)
                    f"1,"                     # side_safe (assume safe)
                    f"{gt_x:.6f},{gt_y:.6f},{gt_z:.6f}," # GT coordinates
-                   f"{x:.6f},{y:.6f},{z:.6f}," # SLAM pose
                    f"{yaw:.6f},"             # yaw
                    f"{speed:.6f},"           # speed
                    f"{time_now:.6f},"        # time

--- a/uav/nav_runtime.py
+++ b/uav/nav_runtime.py
@@ -109,9 +109,9 @@ def setup_environment(args, client, nav_mode="reactive"):
         "frame,flow_left,flow_center,flow_right,"
         "delta_left,delta_center,delta_right,flow_std,"
         "left_count,center_count,right_count,"
-        "brake_thres,dodge_thres,fps,"
+        "brake_thres,fps,"
         "state,collided,obstacle,side_safe,"
-        "pos_x,pos_y,pos_z,slam_x,slam_y,slam_z,yaw,speed,"
+        "pos_x,pos_y,pos_z,yaw,speed,"
         "time,features,simgetimage_s,decode_s,processing_s,loop_s,cpu_percent,memory_rss,"
         "sudden_rise,center_blocked,combination_flow,minimum_flow\n"
     )
@@ -386,7 +386,6 @@ def log_and_record_frame(
         obstacle_detected,
         side_safe,
         brake_thres,
-        dodge_thres,
         simgetimage_s,
         decode_s,
         processing_s,


### PR DESCRIPTION
## Summary
- trim logged columns for reactive navigation
- adjust SLAM log formatting
- clarify README about log contents

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: test_analyse_cli_produces_html, test_finalise_files, test_context_managers, test_logging_context)*

------
https://chatgpt.com/codex/tasks/task_e_6883b31a596c8325999db539397c1d44