### PR TITLE
Use shared FLAGS_DIR constant

### DIFF
--- a/launch_all.py
+++ b/launch_all.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+from uav.paths import FLAGS_DIR
 
 from uav.logging_config import setup_logging
 from uav.utils import retain_recent_logs
@@ -20,12 +21,12 @@ from uav import launch_utils as lutils
 # ---------------------------------------------------------------------------
 # Flag paths are defined at import time so tests may monkeypatch them.
 # ---------------------------------------------------------------------------
-flags_dir = Path("flags")
-AIRSIM_READY_FLAG = flags_dir / "airsim_ready.flag"
-SLAM_READY_FLAG = flags_dir / "slam_ready.flag"
-SLAM_FAILED_FLAG = flags_dir / "slam_failed.flag"
-START_NAV_FLAG = flags_dir / "start_nav.flag"
-STOP_FLAG = flags_dir / "stop.flag"
+flags_dir = FLAGS_DIR
+AIRSIM_READY_FLAG = FLAGS_DIR / "airsim_ready.flag"
+SLAM_READY_FLAG = FLAGS_DIR / "slam_ready.flag"
+SLAM_FAILED_FLAG = FLAGS_DIR / "slam_failed.flag"
+START_NAV_FLAG = FLAGS_DIR / "start_nav.flag"
+STOP_FLAG = FLAGS_DIR / "stop.flag"
 
 # When a shutdown is requested we wait this long for the main process to exit
 # before forcibly terminating it.
@@ -66,7 +67,6 @@ def init_logging_and_flags() -> str:
     logger = logging.getLogger("Launch")
     logger.info("Logging to logs/%s", launch_log)
 
-    flags_dir.mkdir(exist_ok=True)
     return timestamp
 
 # ---------------------------------------------------------------------------
@@ -176,7 +176,7 @@ class Launcher:
                     self.logger.warning("[SHUTDOWN] Forcing main script shutdown...")
                     self.main_proc.kill()
 
-        pid_file = flags_dir / "ue4_sim.pid"
+        pid_file = FLAGS_DIR / "ue4_sim.pid"
         if pid_file.exists():
             try:
                 ue4_pid = int(pid_file.read_text())
@@ -225,7 +225,7 @@ def wait_for_start_flag() -> bool:
 
 def wait_for_slam_done_flag(timeout: float = 15.0) -> bool:
     """Wait for the slam_done.flag to appear, or timeout."""
-    slam_done_flag = flags_dir / "slam_done.flag"
+    slam_done_flag = FLAGS_DIR / "slam_done.flag"
     logger.info("[MAIN] Waiting for SLAM backend to finish (slam_done.flag)...")
     start = time.time()
     while not slam_done_flag.exists():
@@ -349,13 +349,13 @@ def main(timestamp: str, selected_nav_mode: Optional[str] = None) -> bool:
 
 def wait_for_nav_mode_and_launch(timestamp: str) -> None:
     logger.info("Waiting for user to select navigation mode and launch simulation...")
-    while not (flags_dir / "nav_mode.flag").exists():
+    while not (FLAGS_DIR / "nav_mode.flag").exists():
         if STOP_FLAG.exists():
             logger.info("Stop flag detected before simulation started. Shutting down.")
             return
         time.sleep(0.2)
 
-    with open(flags_dir / "nav_mode.flag") as f:
+    with open(FLAGS_DIR / "nav_mode.flag") as f:
         selected_nav_mode = f.read().strip()
     logger.info(f"User selected navigation mode: {selected_nav_mode}")
 
@@ -374,7 +374,7 @@ def cli_main() -> None:
                  SLAM_FAILED_FLAG, 
                  START_NAV_FLAG, 
                  STOP_FLAG, 
-                 flags_dir / "nav_mode.flag",
+                 FLAGS_DIR / "nav_mode.flag",
                  ]:
         flag.unlink(missing_ok=True)
 

--- a/main.py
+++ b/main.py
@@ -1,8 +1,7 @@
 import threading
 import time
 import os
-from pathlib import Path
-from uav.paths import STOP_FLAG_PATH
+from uav.paths import STOP_FLAG_PATH, FLAGS_DIR
 import queue
 from datetime import datetime
 import cv2
@@ -43,9 +42,7 @@ logger.info(
 )
 
 # --- Flag paths ---
-flags_dir = Path("flags")
-flags_dir.mkdir(exist_ok=True)
-START_FLAG_PATH = flags_dir / "start_nav.flag"
+START_FLAG_PATH = FLAGS_DIR / "start_nav.flag"
 
 
 def get_settings_path(args, config):
@@ -156,7 +153,7 @@ def main() -> None:
     nav_mode = getattr(args, "nav_mode", "slam")  # Default to slam if not specified
 
     sim_process = launch_sim(args, settings_path, config)
-    pid_path = Path("flags/ue4_sim.pid")
+    pid_path = FLAGS_DIR / "ue4_sim.pid"
     pid_path.write_text(str(sim_process.pid))
 
     # Wait for the simulator to be ready before connecting the AirSim client
@@ -174,7 +171,7 @@ def main() -> None:
         cleanup(None, sim_process, None)
         return
 
-    (flags_dir / "airsim_ready.flag").touch()
+    (FLAGS_DIR / "airsim_ready.flag").touch()
     logger.info("[INFO] AirSim + camera ready — flag set")
 
     logger.info("[TEST] nav_loop logger test")
@@ -207,12 +204,12 @@ def main() -> None:
                 logger.info("[main.py] Waiting for SLAM receiver to finish...")
                 receiver_thread.join()
                 logger.info("[main.py] SLAM receiver thread joined successfully.")
-            for flag in [flags_dir / "airsim_ready.flag", flags_dir / "start_nav.flag"]:
+            for flag in [FLAGS_DIR / "airsim_ready.flag", FLAGS_DIR / "start_nav.flag"]:
                 try:
                     flag.unlink()
                 except FileNotFoundError:
                     pass
-            Path("flags/slam_shutdown.flag").touch()
+            (FLAGS_DIR / "slam_shutdown.flag").touch()
             logger.info("[main.py] slam_shutdown.flag created to signal SLAM backend to exit.")
             logger.info("[main.py] SLAM navigation loop finished - Calling cleanup.")
             cleanup(client, sim_process, ctx if ctx is not None else None)
@@ -240,7 +237,7 @@ def main() -> None:
             navigation_loop(args, client, ctx)
 
         finally:
-            for flag in [flags_dir / "airsim_ready.flag", flags_dir / "start_nav.flag", flags_dir / "stop.flag"]:
+            for flag in [FLAGS_DIR / "airsim_ready.flag", FLAGS_DIR / "start_nav.flag", FLAGS_DIR / "stop.flag"]:
                 try:
                     flag.unlink()
                 except FileNotFoundError:

--- a/slam_bridge/slam_receiver.py
+++ b/slam_bridge/slam_receiver.py
@@ -7,6 +7,7 @@ import time
 import argparse
 import csv
 from pathlib import Path
+from uav.paths import FLAGS_DIR
 import threading
 import numpy as np
 
@@ -42,7 +43,7 @@ class SlamReceiver:
         if self.receiver is not None:
             self.receiver.start()
             logger.info("[SLAMReceiver] PoseReceiver started.")
-            (Path("flags") / "pose_receiver_ready.flag").touch()
+            (FLAGS_DIR / "pose_receiver_ready.flag").touch()
 
             log_dir = Path("analysis")
             log_dir.mkdir(exist_ok=True)

--- a/slam_bridge/stream_airsim_image.py
+++ b/slam_bridge/stream_airsim_image.py
@@ -1,9 +1,9 @@
 import sys
-from pathlib import Path
 
 import os
 import argparse
 import logging
+from uav.paths import FLAGS_DIR
 
 from datetime import datetime
 
@@ -231,7 +231,7 @@ def parse_args() -> argparse.Namespace:
 # This will parse arguments, set up logging, and start the streamer
 def main() -> None:
     log_name = f"airsim_stream_{datetime.now():%Y%m%d_%H%M%S}.log"
-    Path("flags").mkdir(exist_ok=True)
+    # FLAGS_DIR is imported to ensure the directory exists
     args = parse_args()
     streamer = ImageStreamer(args.host, args.port, args.mode, args.retries)
     try:

--- a/uav/interface.py
+++ b/uav/interface.py
@@ -22,6 +22,7 @@ import tkinter as tk
 from threading import Thread
 from threading import Event
 from .context import ParamRefs
+from uav.paths import FLAGS_DIR
 
 
 # Use a multiprocessing.Event to signal when the application should exit
@@ -48,13 +49,11 @@ def launch_control_gui(param_refs, nav_mode="unknown"):
 
     def on_launch_sim():
         """Write selected nav mode to a flag file to trigger simulation startup."""
-        from pathlib import Path
-        Path("flags/nav_mode.flag").write_text(nav_mode_var.get())
+        (FLAGS_DIR / "nav_mode.flag").write_text(nav_mode_var.get())
 
     def on_start_nav():
         """Create the start_nav.flag to trigger navigation."""
-        from pathlib import Path
-        Path("flags/start_nav.flag").touch()
+        (FLAGS_DIR / "start_nav.flag").touch()
 
 
     def update_status_lights():

--- a/uav/launch_utils.py
+++ b/uav/launch_utils.py
@@ -8,6 +8,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, Tuple
+from uav.paths import STOP_FLAG_PATH
 
 try:
     import pygetwindow as gw
@@ -16,7 +17,7 @@ except Exception:  # pragma: no cover - platform without GUI
 
 # Default stop flag used to cancel wait operations. Tests or callers may
 # monkeypatch this path.
-STOP_FLAG: Path = Path("flags/stop.flag")
+STOP_FLAG: Path = STOP_FLAG_PATH
 
 __all__ = [
     "wait_for_window",


### PR DESCRIPTION
## Summary
- replace direct `Path("flags")` usage with `FLAGS_DIR`
- import `FLAGS_DIR` across modules and rely on `uav.paths` for creating the directory
- remove redundant `mkdir` calls for the flags folder

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6883df39d1888325885fcc68faed80d7