### PR TITLE
Refactor logging helpers

### DIFF
--- a/analysis/analyse.py
+++ b/analysis/analyse.py
@@ -610,7 +610,8 @@ def main(argv: Union[List[str], None] = None) -> None:
 
         if args.output.lower().endswith(".html"):
             logger.info("Generating HTML analysis report...")
-            analyse_logs(args.logs, args.output)
+            log_arg = args.logs[0] if len(args.logs) == 1 else args.logs
+            analyse_logs(log_arg, args.output)
             logger.info(f"✅ Flight analysis completed successfully")
         else:
             if len(args.logs) != 1:

--- a/uav/analysis_helpers.py
+++ b/uav/analysis_helpers.py
@@ -31,11 +31,14 @@ def _generate_visualisation(log_csv_path, analysis_dir, timestamp):
             is_slam_data = slam_states.any()
         
         if is_slam_data:
-            logger.info("Detected SLAM navigation data - generating SLAM-specific visualizations")
+            logger.info(
+                "Detected SLAM navigation data - generating SLAM-specific visualizations"
+            )
             return _generate_slam_visualization(df, analysis_dir, timestamp)
-        else:
-            logger.info("Detected reactive navigation data - generating standard visualizations")
-            return _generate_reactive_visualization(df, analysis_dir, timestamp)
+        logger.info(
+            "Detected reactive navigation data - generating standard visualizations"
+        )
+        return _generate_reactive_visualization(log_csv_path, analysis_dir, timestamp)
             
     except Exception as e:
         logger.error(f"Visualization generation failed: {e}")
@@ -94,10 +97,20 @@ def _generate_slam_visualization(df, analysis_dir, timestamp):
         logger.error(f"Failed to generate SLAM visualization: {e}")
         return None
 
-def _generate_reactive_visualization(df, analysis_dir, timestamp):
-    """Generate reactive navigation visualizations (existing code)."""
-    # Your existing reactive navigation visualization code here
-    pass
+def _generate_reactive_visualization(log_csv_path, analysis_dir, timestamp):
+    """Generate reactive navigation visualizations via ``visualise_flight.py``."""
+    output_path = Path(analysis_dir) / f"flight_visual_{timestamp}.html"
+    script = os.path.abspath("analysis/visualise_flight.py")
+    try:
+        subprocess.run(
+            [sys.executable, script, str(output_path), "--log", str(log_csv_path)],
+            check=True,
+        )
+        logger.info(f"✅ Flight visualisation saved: {output_path}")
+        return str(output_path)
+    except Exception as e:
+        logger.error(f"Visualization generation failed: {e}")
+        return None
 
 
 def _generate_performance(log_csv: Path, analysis_dir: Path, timestamp: str) -> str:

--- a/uav/logging_helpers.py
+++ b/uav/logging_helpers.py
@@ -246,3 +246,30 @@ def finalize_logging(log_file, log_buffer):
             logger.info("Log file closed successfully")
         except Exception as e:
             logger.error(f"Failed to close log file: {e}")
+
+class ThreadManager:
+    """Context manager for shutting down worker threads."""
+
+    def __init__(self, ctx):
+        self.ctx = ctx
+
+    def __enter__(self):
+        return self.ctx
+
+    def __exit__(self, exc_type, exc, tb):
+        from uav.nav_runtime import shutdown_threads
+        shutdown_threads(self.ctx)
+
+
+class LoggingContext:
+    """Context manager for flushing and closing log resources."""
+
+    def __init__(self, ctx):
+        self.ctx = ctx
+
+    def __enter__(self):
+        return self.ctx
+
+    def __exit__(self, exc_type, exc, tb):
+        from uav.nav_runtime import close_logging
+        close_logging(self.ctx)

--- a/uav/nav_analysis.py
+++ b/uav/nav_analysis.py
@@ -62,9 +62,9 @@ def finalise_files(ctx):
 
         try:
             files = [
-                _generate_visualisation(str(log_csv), str(analysis_dir), timestamp),
-                _generate_performance(str(log_csv), str(analysis_dir), timestamp),
-                _generate_report(str(log_csv), str(analysis_dir), timestamp),
+                _generate_visualisation(log_csv, analysis_dir, timestamp),
+                _generate_performance(log_csv, analysis_dir, timestamp),
+                _generate_report(log_csv, analysis_dir, timestamp),
             ]
         except subprocess.CalledProcessError as proc_error:
             logger.error(f"Analysis subprocess failed: {proc_error.stderr}")

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -6,6 +6,7 @@ import numpy as np
 import airsim
 
 import uav.config as uav_config
+from uav.logging_helpers import LoggingContext, ThreadManager
 from uav.nav_runtime import (
     setup_environment,
     check_startup_grace,
@@ -17,7 +18,6 @@ from uav.nav_runtime import (
     check_slam_stop,
     ensure_stable_slam_pose,
     handle_waypoint_progress,
-    ThreadManager,
     SimulationProcess,
     shutdown_threads,
     close_logging,
@@ -37,19 +37,6 @@ from uav.perception_loop import process_perception_data
 from uav.utils import get_drone_state
 
 logger = logging.getLogger("nav_loop")
-
-
-class LoggingContext:
-    """Context manager for flushing and closing log resources."""
-
-    def __init__(self, ctx):
-        self.ctx = ctx
-
-    def __enter__(self):
-        return self.ctx
-
-    def __exit__(self, exc_type, exc, tb):
-        close_logging(self.ctx)
 
 
 def _resolve(cli_val, default_val):

--- a/uav/nav_runtime.py
+++ b/uav/nav_runtime.py
@@ -21,7 +21,11 @@ from uav.navigation import Navigator
 from uav.utils import get_drone_state, retain_recent_logs, init_client
 from uav.utils import retain_recent_files
 from uav import config
-from uav.logging_helpers import write_frame_output
+from uav.logging_helpers import (
+    write_frame_output,
+    ThreadManager,
+    LoggingContext,
+)
 from uav.context import ParamRefs, NavContext
 from uav.perception_loop import (
     perception_loop,
@@ -573,30 +577,6 @@ def shutdown_airsim(client):
         logger.error("Landing error: %s", exc)
 
 
-class ThreadManager:
-    """Context manager for shutting down worker threads."""
-
-    def __init__(self, ctx):
-        self.ctx = ctx
-
-    def __enter__(self):
-        return self.ctx
-
-    def __exit__(self, exc_type, exc, tb):
-        shutdown_threads(self.ctx)
-
-
-class LoggingContext:
-    """Context manager for flushing and closing log resources."""
-
-    def __init__(self, ctx):
-        self.ctx = ctx
-
-    def __enter__(self):
-        return self.ctx
-
-    def __exit__(self, exc_type, exc, tb):
-        close_logging(self.ctx)
 
 
 class SimulationProcess:


### PR DESCRIPTION
## Summary
- centralize thread and logging context managers in `logging_helpers`
- use shared managers in nav runtime and loop
- tweak analyse CLI to handle single log inputs
- wire up visualization helper
- pass paths to analysis helpers correctly

## Testing
- `pytest -q` *(fails: AssertionError and TypeError in cleanup helper tests)*

------
https://chatgpt.com/codex/tasks/task_e_6883dfb465cc8325a853ba70b0c145a2