### PR TITLE
Handle stop flag while waiting for navigation

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,8 +92,14 @@ def get_arg_or_config(args, config, name, section, option, default=None):
         return default
     
 def wait_for_nav_trigger():
+    """Block until the start flag appears, exiting early if the stop flag is set."""
     logger.info("[INFO] Waiting for navigation start flag...")
     while not START_FLAG_PATH.exists():
+        if STOP_FLAG_PATH.exists():
+            logger.info(
+                "[INFO] Stop flag detected while waiting for start. Exiting wait loop."
+            )
+            return
         time.sleep(1)
     logger.info("[INFO] Navigation start flag found. Beginning nav logic...")
 

--- a/tests/test_wait_for_nav_trigger.py
+++ b/tests/test_wait_for_nav_trigger.py
@@ -1,0 +1,22 @@
+import main
+
+
+def test_wait_for_nav_trigger_stops_on_stop(monkeypatch, tmp_path):
+    start = tmp_path / "start.flag"
+    stop = tmp_path / "stop.flag"
+    monkeypatch.setattr(main, "START_FLAG_PATH", start, raising=False)
+    monkeypatch.setattr(main, "STOP_FLAG_PATH", stop, raising=False)
+    monkeypatch.setattr("uav.paths.STOP_FLAG_PATH", stop, raising=False)
+
+    calls = {"sleep": 0}
+
+    def fake_sleep(_):
+        calls["sleep"] += 1
+        stop.touch()
+
+    monkeypatch.setattr(main.time, "sleep", fake_sleep)
+
+    main.wait_for_nav_trigger()
+
+    assert stop.exists()
+    assert calls["sleep"] == 1


### PR DESCRIPTION
## Summary
- break `wait_for_nav_trigger` if the stop flag appears
- add test covering stop flag behaviour

## Testing
- `pytest tests/test_wait_for_nav_trigger.py -q`
- `pytest -q` *(fails: test_analyse_flight, test_cleanup_helpers)*

------
https://chatgpt.com/codex/tasks/task_e_6883e57e836c83258cdf3321562ad94d