### PR TITLE
Enhance log finalization for SLAM runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ setup_logging("run.log")  # also prints to stdout
 
 - Flight logs are stored in `flow_logs/` as `.csv` (use `--output-dir` to change the base folder)
 - When running SLAM navigation the file is named `slam_log_<timestamp>.csv` with minimal pose metrics
+- After each run the appropriate log (reactive or SLAM) is automatically analysed to generate a flight
+  report, performance plots and a 3D trajectory view
 - Each log row contains the AirSim ground truth position (`pos_x`, `pos_y`, `pos_z`)
   along with orientation and performance metrics.
 - 3D trajectory plots are saved in `analysis/` as interactive `.html` files

--- a/uav/nav_analysis.py
+++ b/uav/nav_analysis.py
@@ -31,7 +31,25 @@ def finalise_files(ctx):
 
     try:
         base_dir = Path(getattr(ctx, "output_dir", "."))
-        log_csv = base_dir / "flow_logs" / f"reactive_log_{timestamp}.csv"
+
+        log_csv = None
+        ctx_log_file = getattr(ctx, "log_file", None)
+        if ctx_log_file is not None:
+            try:
+                log_csv = Path(ctx_log_file.name)
+            except Exception:
+                logger.warning("Could not determine log file path from ctx.log_file")
+
+        if log_csv is None:
+            reactive = base_dir / "flow_logs" / f"reactive_log_{timestamp}.csv"
+            slam = base_dir / "flow_logs" / f"slam_log_{timestamp}.csv"
+            if reactive.exists():
+                log_csv = reactive
+            elif slam.exists():
+                log_csv = slam
+            else:
+                logger.error(f"Log file not found: {reactive} or {slam}")
+                return
 
         if not os.path.exists(log_csv):
             logger.error(f"Log file not found: {log_csv}")
@@ -62,9 +80,9 @@ def finalise_files(ctx):
 
         try:
             files = [
-                _generate_visualisation(str(log_csv), str(analysis_dir), timestamp),
-                _generate_performance(str(log_csv), str(analysis_dir), timestamp),
-                _generate_report(str(log_csv), str(analysis_dir), timestamp),
+                _generate_visualisation(log_csv, analysis_dir, timestamp),
+                _generate_performance(log_csv, analysis_dir, timestamp),
+                _generate_report(log_csv, analysis_dir, timestamp),
             ]
         except subprocess.CalledProcessError as proc_error:
             logger.error(f"Analysis subprocess failed: {proc_error.stderr}")


### PR DESCRIPTION
## Summary
- detect slam log files when reactive log not found
- pass selected log path to analysis helpers
- add test for slam log finalization
- ensure CLI analysis works with basic logs
- document automatic analysis of both reactive and SLAM logs

## Testing
- `pip install -r requirements.txt`
- `pip install matplotlib trimesh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883dfed184083258740991214155a18