### PR TITLE
Refactor mesh utilities into dedicated module

### DIFF
--- a/analysis/5_map_overlay.py
+++ b/analysis/5_map_overlay.py
@@ -12,6 +12,11 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
+from .mesh_utils import (
+    add_environment_mesh_to_plot,
+    extract_mesh_data,
+    apply_mesh_corrections,
+)
 
 # Setup logging
 logging.basicConfig(
@@ -108,90 +113,6 @@ def load_environment_mesh():
         logger.error(f"Error in load_environment_mesh: {e}")
         return None
 
-def apply_mesh_corrections(vertices):
-    """Apply coordinate system corrections to mesh vertices."""
-    corrected = vertices.copy()
-    
-    # Swap Y and Z axes
-    corrected[:, [1, 2]] = vertices[:, [2, 1]]
-    
-    # Position mesh to start at X = -0.5
-    x_offset = -0.5 - corrected[:, 0].min()
-    corrected[:, 0] += x_offset
-    
-    # Center mesh at Y = 0
-    y_center = (corrected[:, 1].min() + corrected[:, 1].max()) / 2
-    corrected[:, 1] -= y_center
-    
-    return corrected
-
-def extract_mesh_data(mesh):
-    """Extract vertices and faces from mesh object."""
-    vertices = None
-    faces = None
-    
-    if hasattr(mesh, 'geometry') and mesh.geometry:
-        # Scene object - combine all geometries
-        for geom in mesh.geometry.values():
-            if hasattr(geom, 'vertices') and len(geom.vertices) > 0:
-                if vertices is None:
-                    vertices = geom.vertices.copy()
-                    faces = geom.faces.copy()
-                else:
-                    vertex_offset = len(vertices)
-                    vertices = np.vstack([vertices, geom.vertices])
-                    faces = np.vstack([faces, geom.faces + vertex_offset])
-    elif hasattr(mesh, 'vertices') and hasattr(mesh, 'faces'):
-        # Direct Trimesh object
-        vertices = mesh.vertices.copy()
-        faces = mesh.faces.copy()
-    else:
-        # Try Scene conversion
-        try:
-            combined_mesh = mesh.dump().sum()
-            vertices = combined_mesh.vertices.copy()
-            faces = combined_mesh.faces.copy()
-        except:
-            pass
-    
-    return vertices, faces
-
-def add_environment_mesh_to_plot(fig3d, mesh, opacity=0.15):
-    """Add environment mesh to the 3D plot."""
-    if mesh is None:
-        logger.warning("No mesh provided")
-        return
-        
-    try:
-        vertices, faces = extract_mesh_data(mesh)
-        
-        if vertices is None or len(vertices) == 0:
-            logger.warning("No valid mesh data found")
-            return
-        
-        # Apply mesh corrections
-        vertices = apply_mesh_corrections(vertices)
-        
-        # Simplify mesh for performance if needed
-        if len(faces) > 8000:
-            step = max(1, len(faces) // 8000)
-            faces = faces[::step]
-            logger.info(f"Simplified mesh to {len(faces)} faces for performance")
-        
-        # Add mesh to plot
-        fig3d.add_trace(go.Mesh3d(
-            x=vertices[:, 0], y=vertices[:, 1], z=vertices[:, 2],
-            i=faces[:, 0], j=faces[:, 1], k=faces[:, 2],
-            color='lightgray', opacity=opacity, name="🗺️ Environment",
-            showlegend=True, hoverinfo='skip',
-            lighting=dict(ambient=0.7, diffuse=0.8, specular=0.1),
-            lightposition=dict(x=100, y=200, z=0)
-        ))
-        
-        logger.info(f"✅ Added environment mesh ({len(vertices)} vertices, {len(faces)} faces)")
-        
-    except Exception as e:
-        logger.error(f"Failed to add environment mesh: {e}")
 
 def load_trajectory_from_csv(csv_path: str) -> Optional[tuple]:
     """Load trajectory data from a CSV log file."""

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -9,6 +9,11 @@ from .flight_review import (
 from .summarise_runs import summarise_log
 from . import visualise_flight
 from .performance_plots import plot_performance
+from .mesh_utils import (
+    add_environment_mesh_to_plot,
+    extract_mesh_data,
+    apply_mesh_corrections,
+)
 
 __all__ = [
     "parse_log",
@@ -18,4 +23,7 @@ __all__ = [
     "summarise_log",
     "visualise_flight",
     "plot_performance",
+    "add_environment_mesh_to_plot",
+    "extract_mesh_data",
+    "apply_mesh_corrections",
 ]

--- a/analysis/analyse.py
+++ b/analysis/analyse.py
@@ -78,97 +78,16 @@ except ImportError as e:
         logger.error("Make sure flight_review.py and visualise_flight.py are in the analysis directory")
         sys.exit(1)
 
+# Import mesh utilities
+from .mesh_utils import (
+    add_environment_mesh_to_plot,
+    extract_mesh_data,
+    apply_mesh_corrections,
+)
+
+
 # ========== Analysis Functions ========== #
 # These functions handle the main analysis logic.
-def add_environment_mesh_to_plot(fig3d, mesh, opacity=0.15):
-    """Add environment mesh to the 3D plot."""
-    if mesh is None:
-        logger.warning("No mesh provided to add_environment_mesh_to_plot")
-        return
-        
-    try:
-        # Extract vertices and faces from mesh (handles Scene or Trimesh objects)
-        vertices, faces = extract_mesh_data(mesh)
-        
-        if vertices is None or len(vertices) == 0:
-            logger.warning("No valid mesh data found")
-            return
-        
-        # Apply mesh corrections for AirSim coordinate system
-        vertices = apply_mesh_corrections(vertices)
-        
-        # Simplify mesh for performance if needed
-        if len(faces) > 8000:
-            step = max(1, len(faces) // 8000)
-            faces = faces[::step]
-            logger.info(f"Simplified mesh to {len(faces)} faces for performance")
-        
-        # Add mesh to plot
-        fig3d.add_trace(go.Mesh3d(
-            x=vertices[:, 0], y=vertices[:, 1], z=vertices[:, 2],
-            i=faces[:, 0], j=faces[:, 1], k=faces[:, 2],
-            color='lightgray', opacity=opacity, name="🗺️ Environment Mesh",
-            showlegend=True, hoverinfo='skip',
-            lighting=dict(ambient=0.7, diffuse=0.8, specular=0.1),
-            lightposition=dict(x=100, y=200, z=0)
-        ))
-        
-        logger.info(f"✅ Added environment mesh ({len(vertices)} vertices, {len(faces)} faces)")
-        
-    except Exception as e:
-        logger.error(f"Failed to add environment mesh: {e}")
-
-# Extract vertices and faces from a mesh object, handling both Scene and Trimesh formats.
-def extract_mesh_data(mesh):
-    """Extract vertices and faces from mesh object."""
-    vertices = None
-    faces = None
-    
-    if hasattr(mesh, 'geometry') and mesh.geometry:
-        # Scene object - combine all geometries
-        for geom in mesh.geometry.values():
-            if hasattr(geom, 'vertices') and len(geom.vertices) > 0:
-                if vertices is None:
-                    vertices = geom.vertices.copy()
-                    faces = geom.faces.copy()
-                else:
-                    vertex_offset = len(vertices)
-                    vertices = np.vstack([vertices, geom.vertices])
-                    faces = np.vstack([faces, geom.faces + vertex_offset])
-    elif hasattr(mesh, 'vertices') and hasattr(mesh, 'faces'):
-        # Direct Trimesh object
-        vertices = mesh.vertices.copy()
-        faces = mesh.faces.copy()
-    else:
-        # Try Scene conversion
-        try:
-            combined_mesh = mesh.dump().sum()
-            vertices = combined_mesh.vertices.copy()
-            faces = combined_mesh.faces.copy()
-        except:
-            pass
-    
-    return vertices, faces
-
-# Apply coordinate system corrections to mesh vertices.
-# This adjusts the mesh to match AirSim's coordinate system.
-def apply_mesh_corrections(vertices):
-    """Apply coordinate system corrections to mesh vertices."""
-    corrected = vertices.copy()
-    
-    # 1. Swap Y and Z axes (mesh is rotated)
-    corrected[:, [1, 2]] = vertices[:, [2, 1]]
-    
-    # 2. Position mesh to start at X = -0.5
-    x_offset = -0.5 - corrected[:, 0].min()
-    corrected[:, 0] += x_offset
-    
-    # 3. Center mesh at Y = 0
-    y_center = (corrected[:, 1].min() + corrected[:, 1].max()) / 2
-    corrected[:, 1] -= y_center
-    
-    logger.info(f"Applied mesh corrections: X offset={x_offset:.2f}, Y center={y_center:.2f}")
-    return corrected
 
 def analyse_logs(log_file_path, output_dir):
     """Analyze navigation logs and generate reports."""

--- a/analysis/mesh_utils.py
+++ b/analysis/mesh_utils.py
@@ -1,0 +1,110 @@
+# Utility functions for handling environment meshes in analysis scripts.
+import logging
+import numpy as np
+import plotly.graph_objects as go
+
+logger = logging.getLogger(__name__)
+
+
+def extract_mesh_data(mesh):
+    """Extract vertices and faces from a mesh object."""
+    vertices = None
+    faces = None
+
+    if hasattr(mesh, 'geometry') and mesh.geometry:
+        # Scene object - combine all geometries
+        for geom in mesh.geometry.values():
+            if hasattr(geom, 'vertices') and len(geom.vertices) > 0:
+                if vertices is None:
+                    vertices = geom.vertices.copy()
+                    faces = geom.faces.copy()
+                else:
+                    vertex_offset = len(vertices)
+                    vertices = np.vstack([vertices, geom.vertices])
+                    faces = np.vstack([faces, geom.faces + vertex_offset])
+    elif hasattr(mesh, 'vertices') and hasattr(mesh, 'faces'):
+        # Direct Trimesh object
+        vertices = mesh.vertices.copy()
+        faces = mesh.faces.copy()
+    else:
+        # Try Scene conversion
+        try:
+            combined_mesh = mesh.dump().sum()
+            vertices = combined_mesh.vertices.copy()
+            faces = combined_mesh.faces.copy()
+        except Exception:
+            pass
+
+    return vertices, faces
+
+
+def apply_mesh_corrections(vertices):
+    """Apply coordinate system corrections to mesh vertices."""
+    corrected = vertices.copy()
+
+    # Swap Y and Z axes (mesh is rotated)
+    corrected[:, [1, 2]] = vertices[:, [2, 1]]
+
+    # Position mesh to start at X = -0.5
+    x_offset = -0.5 - corrected[:, 0].min()
+    corrected[:, 0] += x_offset
+
+    # Center mesh at Y = 0
+    y_center = (corrected[:, 1].min() + corrected[:, 1].max()) / 2
+    corrected[:, 1] -= y_center
+
+    logger.info(
+        f"Applied mesh corrections: X offset={x_offset:.2f}, Y center={y_center:.2f}"
+    )
+    return corrected
+
+
+def add_environment_mesh_to_plot(fig3d, mesh, opacity=0.15):
+    """Add environment mesh to the 3D plot."""
+    if mesh is None:
+        logger.warning("No mesh provided to add_environment_mesh_to_plot")
+        return
+
+    try:
+        # Extract vertices and faces
+        vertices, faces = extract_mesh_data(mesh)
+
+        if vertices is None or len(vertices) == 0:
+            logger.warning("No valid mesh data found")
+            return
+
+        # Apply mesh corrections for AirSim coordinate system
+        vertices = apply_mesh_corrections(vertices)
+
+        # Simplify mesh for performance if needed
+        if len(faces) > 8000:
+            step = max(1, len(faces) // 8000)
+            faces = faces[::step]
+            logger.info(f"Simplified mesh to {len(faces)} faces for performance")
+
+        # Add mesh to plot
+        fig3d.add_trace(
+            go.Mesh3d(
+                x=vertices[:, 0],
+                y=vertices[:, 1],
+                z=vertices[:, 2],
+                i=faces[:, 0],
+                j=faces[:, 1],
+                k=faces[:, 2],
+                color="lightgray",
+                opacity=opacity,
+                name="\U0001f5fa\ufe0f Environment Mesh",
+                showlegend=True,
+                hoverinfo="skip",
+                lighting=dict(ambient=0.7, diffuse=0.8, specular=0.1),
+                lightposition=dict(x=100, y=200, z=0),
+            )
+        )
+
+        logger.info(
+            f"\u2705 Added environment mesh ({len(vertices)} vertices, {len(faces)} faces)"
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to add environment mesh: {e}")
+


### PR DESCRIPTION
## Summary
- move mesh utility helpers into `analysis.mesh_utils`
- import mesh utilities from `analyse.py` and `5_map_overlay.py`
- expose mesh utilities in `analysis.__init__`

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6883dfc5c60883259598894e1910bba3