### PR TITLE
Fix translation error plot time scaling

### DIFF
--- a/slam_bridge/pose_comparison_plotter.py
+++ b/slam_bridge/pose_comparison_plotter.py
@@ -163,13 +163,19 @@ def plot_translation_error(df, save_dir="analysis"):
            (df['gt_y_corrected'] - df['slam_y_corrected']) ** 2 +
            (df['gt_z_corrected'] - df['slam_z_corrected']) ** 2) ** 0.5
 
-    xvals = df['timestamp'] if 'timestamp' in df.columns else df.index
+    if 'timestamp' in df.columns:
+        start = df['timestamp'].iloc[0]
+        xvals = df['timestamp'] - start
+        x_title = "Time (s)"
+    else:
+        xvals = df.index
+        x_title = 'Index'
 
     fig = go.Figure()
     fig.add_trace(go.Scatter(x=xvals, y=err, mode='lines', name='error'))
     fig.update_layout(
         title="Translation Error Over Time",
-        xaxis_title="Time (s)" if 'timestamp' in df.columns else 'Index',
+        xaxis_title=x_title,
         yaxis_title="Error (m)",
     )
 


### PR DESCRIPTION
## Summary
- use relative timestamps when plotting SLAM translation error

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6884b208a6408325886238b872f33eb0