### PR TITLE
Add memory support to performance plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ setup_logging("run.log")  # also prints to stdout
 - Generate HTML summaries with `analyse-flight LOG.csv`
 - Run `python -m slam_bridge.slam_plotter` to record SLAM poses and generate a trajectory HTML file
 - Visualise a flight path with `python -m analysis.visualise_flight OUTPUT.html --log LOG.csv --obstacles OBSTACLES.json`
-- Plot CPU and memory usage with `python -m analysis.performance_plots LOG.csv -o OUT.html`
+- Plot CPU and memory usage with `python -m analysis.performance_plots LOG.csv -o OUT.html`. This script handles both `memory_rss` (bytes) and `memory_mb` columns.
 - Generate state histograms and distance plots with `python -m analysis.analyse LOG.csv -o OUT_DIR`
 
 ---

--- a/analysis/performance_plots.py
+++ b/analysis/performance_plots.py
@@ -46,7 +46,13 @@ def build_plot(df: pd.DataFrame) -> Any:
     import plotly.graph_objects as go
 
     cpu = df.get("cpu_percent", pd.Series(dtype=float))
-    mem = df.get("memory_rss", pd.Series(dtype=float)) / (1024 * 1024)
+
+    if "memory_rss" in df.columns:
+        mem = df["memory_rss"] / (1024 * 1024)
+    elif "memory_mb" in df.columns:
+        mem = df["memory_mb"]
+    else:
+        mem = pd.Series(dtype=float)
 
     fig = make_subplots(specs=[[{"secondary_y": True}]])
     fig.add_trace(go.Scatter(x=x, y=cpu, name="CPU %"), secondary_y=False) 


### PR DESCRIPTION
## Summary
- handle `memory_mb` in performance plot generation so SLAM logs show memory usage
- document both memory column formats

## Testing
- `pytest tests/test_performance_plots.py::test_performance_cli_generates_html -q`
- `pytest -q` *(fails: tests/test_cleanup_helpers.py::test_finalise_files_calledprocesserror)*

------
https://chatgpt.com/codex/tasks/task_e_6884b1f4649c8325a205d933bdc90d24