### PR TITLE
Enable automatic SLAM visualisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains the implementation of a reactive obstacle avoidance sys
 - The pose comparison CSV now records the current navigation state
 - Visualises 3D flight paths with interactive HTML output
 - Automatically runs all analysis tools after each simulation and saves the reports
+- Automatically generates a 3D SLAM trajectory visualisation after SLAM runs
 - Compatible with a custom stereo camera setup (`oakd_camera`)
 - Stereo images are streamed in grayscale to reduce processing overhead
 - Works with auto-launched AirSim simulation


### PR DESCRIPTION
## Summary
- add command line options to `generate_slam_visualisation.py`
- call this script from `nav_analysis.finalise_files` when SLAM logs are detected
- note automatic SLAM trajectory visualisation in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884b1a6fb908325868f0653378c4f82