### PR TITLE
Add reset option to clear flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The `hybrid-nav` entry point exposes several options:
 | `--slam-inlier-threshold INT` | Minimum inliers for SLAM stability |
 | `--log-timestamp STR` | Timestamp used to sync logging across modules |
 | `--output-dir DIR` | Directory where logs and analysis files are saved |
+| `--reset` | Delete all flag files before starting a new run |
 
 ### SLAM Stability
 

--- a/launch_all.py
+++ b/launch_all.py
@@ -381,11 +381,18 @@ def cli_main() -> None:
     "Entry point used when executing this module as a script."
     timestamp = init_logging_and_flags()
 
-    for flag in [AIRSIM_READY_FLAG, 
-                 SLAM_READY_FLAG, 
-                 SLAM_FAILED_FLAG, 
-                 START_NAV_FLAG, 
-                 STOP_FLAG, 
+    args = parse_args()
+    if getattr(args, "reset", False):
+        logger.info("[RESET] Clearing flags directory %s", FLAGS_DIR)
+        for f in FLAGS_DIR.glob("*"):
+            if f.is_file():
+                f.unlink(missing_ok=True)
+
+    for flag in [AIRSIM_READY_FLAG,
+                 SLAM_READY_FLAG,
+                 SLAM_FAILED_FLAG,
+                 START_NAV_FLAG,
+                 STOP_FLAG,
                  FLAGS_DIR / "nav_mode.flag",
                  ]:
         flag.unlink(missing_ok=True)

--- a/uav/cli.py
+++ b/uav/cli.py
@@ -47,4 +47,9 @@ def parse_args():
         default=".",
         help="Directory to store logs and analysis outputs",
     )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Remove all existing flag files before starting",
+    )
     return parser.parse_args()

--- a/uav/nav_analysis.py
+++ b/uav/nav_analysis.py
@@ -107,16 +107,14 @@ def finalise_files(ctx):
 
         generated_files = [Path(f) for f in files if f and os.path.exists(f)]
 
-        # Only generate SLAM pose comparison plot in SLAM mode
-        nav_mode = getattr(ctx, "nav_mode", None)
-        if nav_mode == "slam":
-            try:
-                from uav import slam_utils
+        # Generate SLAM pose comparison plot when available
+        try:
+            from uav import slam_utils
 
-                slam_utils.generate_pose_comparison_plot()
-                logger.info("SLAM pose comparison plot generated")
-            except Exception as slam_error:
-                logger.info(f"SLAM plot generation skipped: {slam_error}")
+            slam_utils.generate_pose_comparison_plot()
+            logger.info("SLAM pose comparison plot generated")
+        except Exception as slam_error:
+            logger.info(f"SLAM plot generation skipped: {slam_error}")
 
         if generated_files:
             logger.info("Analysis complete! Generated files:")


### PR DESCRIPTION
## Summary
- add `--reset` CLI flag to remove old flag files
- document the new flag in README
- support clearing the flags directory when launching
- always generate pose comparison plot in post-flight analysis

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884baad51848325b82757d7921803e6